### PR TITLE
Set up strict linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -32,5 +34,9 @@ jobs:
         run: pnpm run format:check
       - name: Build
         run: pnpm run build
+      - name: Lint
+        run: pnpm run lint
+      - name: Knip
+        run: pnpm run knip
       - name: Integration test
         run: pnpm run test:integration

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,26 @@ export default [
     files: ["**/*.{js,mjs,cjs,ts}"],
     rules: {
       curly: ["error", "all"],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "CallExpression[callee.name='Boolean']",
+          message:
+            "Avoid truthiness coercion. Use an explicit condition or comparison instead.",
+        },
+        {
+          selector:
+            "UnaryExpression[operator='!'] > BinaryExpression[operator='!=']",
+          message:
+            "Avoid negating comparisons. Use the inverse operator directly.",
+        },
+        {
+          selector:
+            "UnaryExpression[operator='!'] > BinaryExpression[operator='!==']",
+          message:
+            "Avoid negating comparisons. Use the inverse operator directly.",
+        },
+      ],
     },
   },
   ...[

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,32 @@
-import parser from "@typescript-eslint/parser";
+import tseslint from "typescript-eslint";
 
 export default [
   {
+    ignores: ["dist/**"],
+  },
+  {
     files: ["**/*.{js,mjs,cjs,ts}"],
-    languageOptions: {
-      parser,
-    },
     rules: {
       curly: ["error", "all"],
+    },
+  },
+  ...[
+    ...tseslint.configs.strictTypeChecked,
+    ...tseslint.configs.stylisticTypeChecked,
+  ].map((config) => ({
+    ...config,
+    files: ["**/*.ts"],
+  })),
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.eslint.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,12 @@ export default [
       },
     },
     rules: {
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "never",
+        },
+      ],
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],
       "@typescript-eslint/prefer-readonly": "error",
       "@typescript-eslint/strict-boolean-expressions": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,11 @@
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default [
   {
     ignores: ["dist/**"],
   },
+  js.configs.recommended,
   {
     files: ["**/*.{js,mjs,cjs,ts}"],
     rules: {
@@ -27,6 +29,10 @@ export default [
     },
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      "@typescript-eslint/prefer-readonly": "error",
+      "@typescript-eslint/strict-boolean-expressions": "error",
+      "@typescript-eslint/strict-void-return": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import parser from "@typescript-eslint/parser";
+
+export default [
+  {
+    files: ["**/*.{js,mjs,cjs,ts}"],
+    languageOptions: {
+      parser,
+    },
+    rules: {
+      curly: ["error", "all"],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@types/node": "^26.1.2",
-    "@typescript-eslint/parser": "^8.67.0",
     "effect": "^3.21.2",
     "eslint": "^10.8.1",
     "prettier": "^3.8.3",
     "tsdown": "0.22.14",
     "typescript": "^6.0.3",
+    "typescript-eslint": "^8.67.0",
     "vitest": "4.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build": "tsdown && tsc --emitDeclarationOnly",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lint": "eslint .",
     "test:integration": "pnpm run build && tsc --noEmit -p tsconfig.test.json && vitest run test/integration"
   },
   "dependencies": {
@@ -52,7 +53,9 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@types/node": "^26.1.2",
+    "@typescript-eslint/parser": "^8.67.0",
     "effect": "^3.21.2",
+    "eslint": "^10.8.1",
     "prettier": "^3.8.3",
     "tsdown": "0.22.14",
     "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -40,22 +40,24 @@
     "build": "tsdown && tsc --emitDeclarationOnly",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "knip": "knip --strict --treat-config-hints-as-errors --treat-tag-hints-as-errors",
     "lint": "eslint .",
     "test:integration": "pnpm run build && tsc --noEmit -p tsconfig.test.json && vitest run test/integration"
   },
   "dependencies": {
+    "@langfuse/otel": "^5.10.1",
     "@opencode-ai/plugin": "^1.15.13",
-    "@opentelemetry/api": "^1.9.1"
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@opentelemetry/sdk-trace-node": "^2.10.0",
+    "effect": "^3.22.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@langfuse/otel": "^5.4.1",
-    "@opentelemetry/resources": "^2.7.1",
-    "@opentelemetry/sdk-trace-base": "^2.7.1",
-    "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@types/node": "^26.1.2",
-    "effect": "^3.21.2",
     "eslint": "^10.8.1",
+    "knip": "^6.32.2",
     "prettier": "^3.8.3",
     "tsdown": "0.22.14",
     "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@opentelemetry/api": "^1.9.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@langfuse/otel": "^5.4.1",
     "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/sdk-trace-base": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,54 +8,66 @@ importers:
 
   .:
     dependencies:
+      '@langfuse/otel':
+        specifier: ^5.10.1
+        version: 5.10.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       '@opencode-ai/plugin':
         specifier: ^1.15.13
         version: 1.15.13
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/resources':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      effect:
+        specifier: ^3.22.1
+        version: 3.22.1
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.1)
-      '@langfuse/otel':
-        specifier: ^5.4.1
-        version: 5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
-      '@opentelemetry/resources':
-        specifier: ^2.7.1
-        version: 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base':
-        specifier: ^2.7.1
-        version: 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node':
-        specifier: ^2.7.1
-        version: 2.7.1(@opentelemetry/api@1.9.1)
+        version: 10.0.1(eslint@10.8.1(jiti@2.7.0))
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
-      effect:
-        specifier: ^3.21.2
-        version: 3.21.2
       eslint:
         specifier: ^10.8.1
-        version: 10.8.1
+        version: 10.8.1(jiti@2.7.0)
+      knip:
+        specifier: ^6.32.2
+        version: 6.32.2
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
       tsdown:
         specifier: 0.22.14
-        version: 0.22.14(typescript@6.0.3)
+        version: 0.22.14(oxc-resolver@11.24.2)(typescript@6.0.3)(unrun@0.3.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+        version: 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
+
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -119,13 +131,13 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@langfuse/core@5.4.1':
-    resolution: {integrity: sha512-TjaRTr9fGqaWuyYKFSezKxN4DWAaK/lq//hRMw8rQKFkZUs6vTgUODxqZTFTR6np5VnLVw+eZLlnHROPKbXqdg==}
+  '@langfuse/core@5.10.1':
+    resolution: {integrity: sha512-W8UArizWSy1DdeLGTsTwJwl7bkA7OQQcGZW8RtoopXyJZ93O0rwG7wzzeiZjhjpj5OtWOUTEaJuNkwOrF31UDw==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/otel@5.4.1':
-    resolution: {integrity: sha512-w69aVC2fTmd7hyCTaX8zhhivHlsGVgZ551XOf6yMSOi3k8tlDML4dinnjJUP/6qTvdH54NYcmAIp5KZRbkouxg==}
+  '@langfuse/otel@5.10.1':
+    resolution: {integrity: sha512-F2153e4PoJ1cN+5tM/xnsS44aQCQwK3p0nPk4NEpITV5pMTqiQVyvpkAvly8GKQ5Qjjr7heJ1dFtghW43ysyPQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -163,6 +175,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
   '@opencode-ai/plugin@1.15.13':
     resolution: {integrity: sha512-NFwZGhmxIPijtfz9swPJXDmhOpq4UWP8WjEE7GEMr7FwtJrK/hv6v36nFimed5+OKk+pQCrTJn/vhRW7Io72IA==}
     peerDependencies:
@@ -180,80 +199,314 @@ packages:
   '@opencode-ai/sdk@1.15.13':
     resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
 
-  '@opentelemetry/api-logs@0.218.0':
-    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/context-async-hooks@2.7.1':
-    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/exporter-trace-otlp-http@0.218.0':
-    resolution: {integrity: sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==}
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.218.0':
-    resolution: {integrity: sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==}
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.218.0':
-    resolution: {integrity: sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==}
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.218.0':
-    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-metrics@2.7.1':
-    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.7.1':
-    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-node@2.7.1':
-    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/semantic-conventions@1.41.1':
-    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
+
+  '@oxc-parser/binding-android-arm-eabi@0.143.0':
+    resolution: {integrity: sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.143.0':
+    resolution: {integrity: sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.143.0':
+    resolution: {integrity: sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.143.0':
+    resolution: {integrity: sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.143.0':
+    resolution: {integrity: sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
+    resolution: {integrity: sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
+    resolution: {integrity: sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
+    resolution: {integrity: sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
+    resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
+    resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
+    resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
+    resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
+    resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
+    resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.143.0':
+    resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.143.0':
+    resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
+    resolution: {integrity: sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
+    resolution: {integrity: sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
+    resolution: {integrity: sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -353,6 +606,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -667,8 +923,8 @@ packages:
       oxc-resolver:
         optional: true
 
-  effect@3.21.2:
-    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+  effect@3.22.1:
+    resolution: {integrity: sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==}
 
   effect@4.0.0-beta.66:
     resolution: {integrity: sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==}
@@ -750,6 +1006,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -777,10 +1036,18 @@ packages:
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-tsconfig@4.14.1:
+    resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
 
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
@@ -824,6 +1091,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -835,6 +1106,11 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  knip@6.32.2:
+    resolution: {integrity: sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
@@ -961,6 +1237,13 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxc-parser@0.143.0:
+    resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1056,6 +1339,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1065,6 +1352,10 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1129,6 +1420,9 @@ packages:
       unrun:
         optional: true
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1145,11 +1439,25 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  unbash@4.0.10:
+    resolution: {integrity: sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==}
+    engines: {node: '>=14'}
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1246,6 +1554,10 @@ packages:
       jsdom:
         optional: true
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1281,11 +1593,30 @@ packages:
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1)':
+  '@emnapi/core@1.11.2':
     dependencies:
-      eslint: 10.8.1
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(jiti@2.7.0))':
+    dependencies:
+      eslint: 10.8.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1306,9 +1637,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.1)':
+  '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.8.1
+      eslint: 10.8.1(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -1335,17 +1666,17 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@langfuse/core@5.4.1(@opentelemetry/api@1.9.1)':
+  '@langfuse/core@5.10.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/otel@5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))':
+  '@langfuse/otel@5.10.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@langfuse/core': 5.4.1(@opentelemetry/api@1.9.1)
+      '@langfuse/core': 5.10.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -1365,6 +1696,13 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@opencode-ai/plugin@1.15.13':
     dependencies:
       '@opencode-ai/sdk': 1.15.13
@@ -1375,83 +1713,209 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@opentelemetry/api-logs@0.218.0':
+  '@opentelemetry/api-logs@0.221.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-exporter-base@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/semantic-conventions@1.41.1': {}
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@oxc-parser/binding-android-arm-eabi@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
+    optional: true
 
   '@oxc-project/types@0.142.0': {}
+
+  '@oxc-project/types@0.143.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -1503,6 +1967,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1520,15 +1989,15 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.67.0
-      eslint: 10.8.1
+      eslint: 10.8.1(jiti@2.7.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -1536,14 +2005,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
-      eslint: 10.8.1
+      eslint: 10.8.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -1566,13 +2035,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.8.1
+      eslint: 10.8.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1595,13 +2064,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      eslint: 10.8.1
+      eslint: 10.8.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -1620,13 +2089,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.6(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.6(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.0(@types/node@26.1.2)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -1771,9 +2240,11 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dts-resolver@3.0.0: {}
+  dts-resolver@3.0.0(oxc-resolver@11.24.2):
+    optionalDependencies:
+      oxc-resolver: 11.24.2
 
-  effect@3.21.2:
+  effect@3.22.1:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
@@ -1808,9 +2279,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.1:
+  eslint@10.8.1(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
@@ -1840,6 +2311,8 @@ snapshots:
       minimatch: 10.2.6
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1881,6 +2354,10 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -1903,8 +2380,16 @@ snapshots:
 
   flatted@3.4.4: {}
 
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
+
   fsevents@2.3.3:
     optional: true
+
+  get-tsconfig@4.14.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.5:
     dependencies:
@@ -1934,6 +2419,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.7.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -1943,6 +2430,22 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  knip@6.32.2:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.1
+      jiti: 2.7.0
+      oxc-parser: 0.143.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.5
+      smol-toml: 1.8.0
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.10
+      yaml: 2.9.0
+      zod: 4.4.3
 
   kubernetes-types@1.30.0: {}
 
@@ -2052,6 +2555,52 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxc-parser@0.143.0:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.143.0
+      '@oxc-parser/binding-android-arm64': 0.143.0
+      '@oxc-parser/binding-darwin-arm64': 0.143.0
+      '@oxc-parser/binding-darwin-x64': 0.143.0
+      '@oxc-parser/binding-freebsd-x64': 0.143.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.143.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.143.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.143.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.143.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.143.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-x64-musl': 0.143.0
+      '@oxc-parser/binding-openharmony-arm64': 0.143.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.143.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.143.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -2090,9 +2639,9 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.2)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.2)(typescript@6.0.3):
     dependencies:
-      dts-resolver: 3.0.0
+      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
       rolldown: 1.2.2
@@ -2134,11 +2683,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  smol-toml@1.8.0: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@4.2.0: {}
+
+  strip-json-comments@5.0.3: {}
 
   tinybench@2.9.0: {}
 
@@ -2159,7 +2712,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  tsdown@0.22.14(typescript@6.0.3):
+  tsdown@0.22.14(oxc-resolver@11.24.2)(typescript@6.0.3)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -2170,7 +2723,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.2
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.2)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.2)(typescript@6.0.3)
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -2178,28 +2731,34 @@ snapshots:
       verkit: 0.3.2
     optionalDependencies:
       typescript: 6.0.3
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@typescript/native-preview'
       - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
 
+  tslib@2.8.1:
+    optional: true
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@6.0.3):
+  typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
-      eslint: 10.8.1
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.8.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@6.0.3: {}
+
+  unbash@4.0.10: {}
 
   unconfig-core@7.5.0:
     dependencies:
@@ -2207,6 +2766,11 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@8.3.0: {}
+
+  unrun@0.3.1:
+    dependencies:
+      rolldown: 1.2.2
+    optional: true
 
   uri-js@4.4.1:
     dependencies:
@@ -2216,7 +2780,7 @@ snapshots:
 
   verkit@0.3.2: {}
 
-  vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0):
+  vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -2226,12 +2790,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.2
       fsevents: 2.3.3
+      jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.6(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -2248,13 +2813,15 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.0(@types/node@26.1.2)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.2
     transitivePeerDependencies:
       - msw
+
+  walk-up-path@4.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -2311,3 +2878,5 @@ snapshots:
       '@yuku-parser/binding-win32-x64': 0.8.3
 
   zod@4.1.8: {}
+
+  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
-      '@typescript-eslint/parser':
-        specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1)(typescript@6.0.3)
       effect:
         specifier: ^3.21.2
         version: 3.21.2
@@ -48,6 +45,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.67.0
+        version: 8.67.0(eslint@10.8.1)(typescript@6.0.3)
       vitest:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0))
@@ -360,6 +360,14 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.67.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.67.0':
     resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -383,6 +391,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.67.0':
     resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -391,6 +406,13 @@ packages:
     resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/visitor-keys@8.67.0':
@@ -763,6 +785,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -1095,6 +1121,13 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1105,6 +1138,11 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1471,6 +1509,22 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 10.8.1
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.67.0
@@ -1501,6 +1555,18 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.8.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.67.0': {}
 
   '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
@@ -1514,6 +1580,17 @@ snapshots:
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      eslint: 10.8.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -1830,6 +1907,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.6: {}
+
   import-without-cache@0.4.0: {}
 
   imurmurhash@0.1.4: {}
@@ -2097,6 +2176,17 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      eslint: 10.8.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@6.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^1.9.1
         version: 1.9.1
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.1)
       '@langfuse/otel':
         specifier: ^5.4.1
         version: 5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
@@ -75,6 +78,15 @@ packages:
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -1138,11 +1150,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-    peerDependencies:
-      synckit: ^0.11.11
-    peerDependenciesMeta:
-      synckit:
-        optional: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1298,6 +1305,10 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.8.1)':
+    optionalDependencies:
+      eslint: 10.8.1
 
   '@eslint/object-schema@3.0.5': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,15 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
+      '@typescript-eslint/parser':
+        specifier: ^8.67.0
+        version: 8.67.0(eslint@10.8.1)(typescript@6.0.3)
       effect:
         specifier: ^3.21.2
         version: 3.21.2
+      eslint:
+        specifier: ^10.8.1
+        version: 10.8.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -47,6 +53,56 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.2.0(@types/node@26.1.2)(yaml@2.9.0))
 
 packages:
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -292,11 +348,54 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
@@ -462,6 +561,19 @@ packages:
   '@yuku-toolchain/types@0.8.3':
     resolution: {integrity: sha512-9LN3HYs3A9qSPVFunsxlbfwBcUgexti3TmhOzIxB/UH8zFuaHQJXTRDcN17DW6cp1GsyZtiZA7f18uIra36Jag==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -469,6 +581,14 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -484,6 +604,18 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -514,8 +646,54 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -529,6 +707,15 @@ packages:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -538,8 +725,23 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -550,22 +752,58 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -641,8 +879,19 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
@@ -659,6 +908,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
@@ -666,6 +918,22 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -685,10 +953,18 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -724,6 +1000,11 @@ packages:
   rolldown@1.2.2:
     resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   shebang-command@2.0.0:
@@ -770,6 +1051,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tsdown@0.22.14:
     resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -804,6 +1091,10 @@ packages:
       unrun:
         optional: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -814,6 +1105,9 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
@@ -917,10 +1211,18 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yuku-ast@0.8.3:
     resolution: {integrity: sha512-8x34yU5uhHUnJXzy2Qvjvec/vE9BzS0/2khVT1MsLmSLO/P8Q1Wp8IxHv+IhD+HMYETk6kherOSvP4JPWw2joQ==}
@@ -935,6 +1237,52 @@ packages:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
 snapshots:
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1)':
+    dependencies:
+      eslint: 10.8.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1113,11 +1461,67 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
+
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      eslint: 10.8.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.67.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/types@8.67.0': {}
+
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.1
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -1234,9 +1638,28 @@ snapshots:
 
   '@yuku-toolchain/types@0.8.3': {}
 
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ansis@4.3.1: {}
 
   assertion-error@2.0.1: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
 
   cac@7.0.0: {}
 
@@ -1249,6 +1672,12 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   defu@6.1.7: {}
 
@@ -1278,9 +1707,75 @@ snapshots:
 
   es-module-lexer@2.3.1: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   expect-type@1.4.0: {}
 
@@ -1292,11 +1787,33 @@ snapshots:
     dependencies:
       pure-rand: 8.4.0
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   find-my-way-ts@0.1.6: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1305,15 +1822,44 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   hookable@6.1.1: {}
+
+  ignore@5.3.2: {}
 
   import-without-cache@0.4.0: {}
 
+  imurmurhash@0.1.4: {}
+
   ini@6.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   isexe@2.0.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kubernetes-types@1.30.0: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1364,9 +1910,19 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
     dependencies:
@@ -1388,12 +1944,33 @@ snapshots:
 
   nanoid@3.3.17: {}
 
+  natural-compare@1.4.0: {}
+
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
     optional: true
 
   obug@2.1.4: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -1409,7 +1986,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   prettier@3.8.3: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
@@ -1453,6 +2034,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.2
       '@rolldown/binding-win32-x64-msvc': 1.2.2
 
+  semver@7.8.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -1482,6 +2065,10 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tsdown@0.22.14(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
@@ -1507,6 +2094,10 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   typescript@6.0.3: {}
 
   unconfig-core@7.5.0:
@@ -1515,6 +2106,10 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@8.3.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   uuid@13.0.2: {}
 
@@ -1569,7 +2164,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   yaml@2.9.0: {}
+
+  yocto-queue@0.1.0: {}
 
   yuku-ast@0.8.3:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ const main = Effect.gen(function* () {
       runHook(
         "config",
         Effect.gen(function* () {
-          if (!(config.experimental?.openTelemetry ?? false)) {
+          if (config.experimental?.openTelemetry !== true) {
             yield* log(
               "warn",
               "[Tracing disabled] Please enable `experimental.openTelemetry` in your opencode.jsonc to use the Langfuse plugin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-  if (publicKey && secretKey) {
+  if (Boolean(publicKey) && secretKey) {
     return {
       publicKey,
       secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -725,7 +725,7 @@ const main = Effect.gen(function* () {
   return hooks;
 });
 
-export const LangfusePlugin: Plugin = async ({ client }) => {
+const LangfusePlugin: Plugin = async ({ client }) => {
   const clientLayer = Layer.succeed(OpencodeClientService, client);
 
   return Effect.runPromise(main.pipe(Effect.provide(clientLayer)));

--- a/src/index.ts
+++ b/src/index.ts
@@ -690,8 +690,7 @@ const main = Effect.gen(function* () {
           }
 
           if (normalized.isError) {
-            yield* Effect.sync(() =>
-              // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
+            yield* Effect.sync(() => {
               langfuse.traceToolError({
                 sessionID: input.sessionID,
                 callID: input.callID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -700,14 +700,13 @@ const main = Effect.gen(function* () {
                   normalized.output ||
                   `MCP tool "${input.tool}" returned an error`,
                 completed: Date.now(),
-              }),
-            );
+              });
+            });
             return;
           }
 
           yield* Effect.try({
-            try: () =>
-              // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
+            try: () => {
               langfuse.traceToolEnd({
                 sessionID: input.sessionID,
                 callID: input.callID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
-  if ((publicKey ?? "") !== "" && Boolean(secretKey)) {
+  if ((publicKey ?? "") !== "" && (secretKey ?? "") !== "") {
     return {
       publicKey,
       secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,8 +158,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       langfuse.endActiveGenerationSteps(sessionID);
       langfuse.endActiveTurnObservations(sessionID);
 
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (sessionID) {
+      if (Boolean(sessionID)) {
         langfuse.clearSessionTraceState(sessionID);
       } else {
         langfuse.clearTraceState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,8 +271,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
 
     if (
       event.type === "session.next.tool.called" &&
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      event.properties.assistantMessageID
+      (event.properties.assistantMessageID ?? "")
     ) {
       langfuse.rememberToolCall({
         callID: event.properties.callID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,8 +336,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
         started: message.time.created,
       });
 
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (!message.time.completed) {
+      if (!(message.time.completed ?? 0)) {
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       });
     }
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (event.type === "session.error" && event.properties.sessionID) {
+    if (event.type === "session.error" && (event.properties.sessionID ?? "")) {
       langfuse.traceSessionError({
         sessionID: event.properties.sessionID,
         error: event.properties.error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,8 +647,7 @@ const main = Effect.gen(function* () {
             tools = yield* Effect.promise(() => pendingTools);
           }
 
-          yield* Effect.sync(() =>
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
+          yield* Effect.sync(() => {
             langfuse.traceUserMessage({
               sessionID: input.sessionID,
               messageID: input.messageID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       langfuse.endActiveGenerationSteps(sessionID);
       langfuse.endActiveTurnObservations(sessionID);
 
-      if ((sessionID ?? "") !== "") {
+      if (sessionID !== undefined && sessionID !== "") {
         langfuse.clearSessionTraceState(sessionID);
       } else {
         langfuse.clearTraceState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
   if (publicKey && secretKey) {
     return {
       publicKey,
@@ -158,6 +159,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       langfuse.endActiveGenerationSteps(sessionID);
       langfuse.endActiveTurnObservations(sessionID);
 
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (sessionID) {
         langfuse.clearSessionTraceState(sessionID);
       } else {
@@ -196,6 +198,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       });
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (event.type === "session.error" && event.properties.sessionID) {
       langfuse.traceSessionError({
         sessionID: event.properties.sessionID,
@@ -271,6 +274,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
 
     if (
       event.type === "session.next.tool.called" &&
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       event.properties.assistantMessageID
     ) {
       langfuse.rememberToolCall({
@@ -336,6 +340,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
         started: message.time.created,
       });
 
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (!message.time.completed) {
         return;
       }
@@ -588,6 +593,7 @@ const main = Effect.gen(function* () {
       runHook(
         "config",
         Effect.gen(function* () {
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
           if (!config.experimental?.openTelemetry) {
             yield* log(
               "warn",

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,7 @@ const createShutdownOnce = (langfuse: LangfuseClient) => {
   let shutdownPromise: Promise<void> | undefined;
 
   return () => {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation tracked for incremental cleanup.
     if (!shutdownPromise) {
       shutdownPromise = Effect.runPromise(langfuse.shutdown);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,13 +139,12 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   );
 
   const credentials = yield* Effect.tryPromise({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation tracked for incremental cleanup.
-    try: async () => JSON.parse(await readFile(configPath, "utf8")),
+    try: async () =>
+      Schema.decodeUnknownSync(Schema.parseJson(LangfuseCredentialsSchema))(
+        await readFile(configPath, "utf8"),
+      ),
     catch: () => new MissingLangfuseCredentials(),
-  }).pipe(
-    Effect.flatMap(Schema.decodeUnknown(LangfuseCredentialsSchema)),
-    Effect.mapError(() => new MissingLangfuseCredentials()),
-  );
+  }).pipe(Effect.mapError(() => new MissingLangfuseCredentials()));
 
   if (!credentials.publicKey || !credentials.secretKey) {
     return yield* Effect.fail(new MissingLangfuseCredentials());

--- a/src/index.ts
+++ b/src/index.ts
@@ -664,14 +664,14 @@ const main = Effect.gen(function* () {
       runHook(
         "tool.execute.before",
         Effect.try({
-          try: () =>
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
+          try: () => {
             langfuse.traceToolStart({
               sessionID: input.sessionID,
               callID: input.callID,
               tool: input.tool,
               args: output.args,
-            }),
+            });
+          },
           catch: (error) => error,
         }),
       ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,12 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
-  if ((publicKey ?? "") !== "" && (secretKey ?? "") !== "") {
+  if (
+    publicKey !== undefined &&
+    publicKey !== "" &&
+    secretKey !== undefined &&
+    secretKey !== ""
+  ) {
     return {
       publicKey,
       secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   );
 
   const credentials = yield* Effect.tryPromise({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation tracked for incremental cleanup.
     try: async () => JSON.parse(await readFile(configPath, "utf8")),
     catch: () => new MissingLangfuseCredentials(),
   }).pipe(

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       });
     }
 
-    if (event.type === "session.error" && (event.properties.sessionID ?? "")) {
+    if (event.type === "session.error" && event.properties.sessionID != null) {
       langfuse.traceSessionError({
         sessionID: event.properties.sessionID,
         error: event.properties.error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -588,8 +588,7 @@ const main = Effect.gen(function* () {
       runHook(
         "config",
         Effect.gen(function* () {
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-          if (!config.experimental?.openTelemetry) {
+          if (!(config.experimental?.openTelemetry ?? false)) {
             yield* log(
               "warn",
               "[Tracing disabled] Please enable `experimental.openTelemetry` in your opencode.jsonc to use the Langfuse plugin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,8 +114,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-  if (Boolean(publicKey) && secretKey) {
+  if (Boolean(publicKey) && Boolean(secretKey)) {
     return {
       publicKey,
       secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -431,8 +431,9 @@ const flattenMcpContent = (content: readonly unknown[]) => {
 
   for (const part of content) {
     const decoded = Schema.decodeUnknownOption(McpContentSchema)(part);
-    // eslint-disable-next-line curly -- Existing violation, fixed in a follow-up commit.
-    if (Option.isNone(decoded)) continue;
+    if (Option.isNone(decoded)) {
+      continue;
+    }
 
     if (decoded.value.type === "text") {
       textParts.push(decoded.value.text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,7 +341,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
         started: message.time.created,
       });
 
-      if (!(message.time.completed ?? 0)) {
+      if (message.time.completed === undefined) {
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   );
 
   const credentials = yield* Effect.tryPromise({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation; fix separately.
     try: async () => JSON.parse(await readFile(configPath, "utf8")),
     catch: () => new MissingLangfuseCredentials(),
   }).pipe(
@@ -475,6 +476,7 @@ const createShutdownOnce = (langfuse: LangfuseClient) => {
   let shutdownPromise: Promise<void> | undefined;
 
   return () => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation; fix separately.
     if (!shutdownPromise) {
       shutdownPromise = Effect.runPromise(langfuse.shutdown);
     }
@@ -646,6 +648,7 @@ const main = Effect.gen(function* () {
           }
 
           yield* Effect.sync(() =>
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
             langfuse.traceUserMessage({
               sessionID: input.sessionID,
               messageID: input.messageID,
@@ -663,6 +666,7 @@ const main = Effect.gen(function* () {
         "tool.execute.before",
         Effect.try({
           try: () =>
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
             langfuse.traceToolStart({
               sessionID: input.sessionID,
               callID: input.callID,
@@ -688,6 +692,7 @@ const main = Effect.gen(function* () {
 
           if (normalized.isError) {
             yield* Effect.sync(() =>
+              // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
               langfuse.traceToolError({
                 sessionID: input.sessionID,
                 callID: input.callID,
@@ -704,6 +709,7 @@ const main = Effect.gen(function* () {
 
           yield* Effect.try({
             try: () =>
+              // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
               langfuse.traceToolEnd({
                 sessionID: input.sessionID,
                 callID: input.callID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -481,12 +481,7 @@ const createShutdownOnce = (langfuse: LangfuseClient) => {
   let shutdownPromise: Promise<void> | undefined;
 
   return () => {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation tracked for incremental cleanup.
-    if (!shutdownPromise) {
-      shutdownPromise = Effect.runPromise(langfuse.shutdown);
-    }
-
-    return shutdownPromise;
+    return (shutdownPromise ??= Effect.runPromise(langfuse.shutdown));
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -714,7 +714,8 @@ const main = Effect.gen(function* () {
                 args: input.args,
                 title: normalized.title,
                 output: normalized.output,
-              }),
+              });
+            },
             catch: (error) => error,
           });
         }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const loadLangfuseCredentials = Effect.gen(function* () {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
 
-  if (Boolean(publicKey) && Boolean(secretKey)) {
+  if ((publicKey ?? "") !== "" && Boolean(secretKey)) {
     return {
       publicKey,
       secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
 
     if (
       event.type === "session.next.tool.called" &&
-      (event.properties.assistantMessageID ?? "")
+      event.properties.assistantMessageID != null
     ) {
       langfuse.rememberToolCall({
         callID: event.properties.callID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ const eventHook = (event: OpencodeEvent, shutdown?: () => Promise<void>) =>
       langfuse.endActiveGenerationSteps(sessionID);
       langfuse.endActiveTurnObservations(sessionID);
 
-      if (Boolean(sessionID)) {
+      if ((sessionID ?? "") !== "") {
         langfuse.clearSessionTraceState(sessionID);
       } else {
         langfuse.clearTraceState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,6 +426,7 @@ const flattenMcpContent = (content: readonly unknown[]) => {
 
   for (const part of content) {
     const decoded = Schema.decodeUnknownOption(McpContentSchema)(part);
+    // eslint-disable-next-line curly -- Existing violation, fixed in a follow-up commit.
     if (Option.isNone(decoded)) continue;
 
     if (decoded.value.type === "text") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,8 +655,8 @@ const main = Effect.gen(function* () {
               model: input.model,
               parts: output.parts,
               tools,
-            }),
-          );
+            });
+          });
         }),
       ),
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1178,7 +1178,7 @@ export class LangfuseClient {
   private getSessionParentSpan(sessionID: string) {
     const parentSessionID = this.traceState.sessionParentIds.get(sessionID);
 
-    if (!(parentSessionID ?? "")) {
+    if (!(parentSessionID != null)) {
       return undefined;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -387,7 +387,7 @@ export class LangfuseClient {
     }
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (existingStep && !existingStep.messageID && messageID) {
+    if (existingStep && !(existingStep.messageID ?? "") && messageID) {
       const updatedStep = {
         ...existingStep,
         sessionID: input.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -842,8 +842,7 @@ export class LangfuseClient {
             input.assistantMessageID,
           ) ??
           (activeStep?.messageID === input.assistantMessageID ||
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-          !activeStep?.messageID
+          !(activeStep?.messageID ?? "")
             ? activeStep
             : undefined))
         : activeStep;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -589,8 +589,7 @@ export class LangfuseClient {
         messageID: input.messageID,
       } satisfies TurnObservation;
 
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (input.messageID) {
+      if (input.messageID ?? "") {
         this.traceState.turnObservationsByMessageId.set(
           input.messageID,
           observation,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -836,17 +836,17 @@ export class LangfuseClient {
     const activeStep = this.traceState.activeGenerationSteps.get(
       input.sessionID,
     );
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    const step = input.assistantMessageID
-      ? (this.traceState.activeGenerationStepsByMessageId.get(
-          input.assistantMessageID,
-        ) ??
-        (activeStep?.messageID === input.assistantMessageID ||
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-        !activeStep?.messageID
-          ? activeStep
-          : undefined))
-      : activeStep;
+    const step =
+      (input.assistantMessageID ?? "")
+        ? (this.traceState.activeGenerationStepsByMessageId.get(
+            input.assistantMessageID,
+          ) ??
+          (activeStep?.messageID === input.assistantMessageID ||
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
+          !activeStep?.messageID
+            ? activeStep
+            : undefined))
+        : activeStep;
 
     if (step) {
       step.span.setAttribute(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1101,7 +1101,7 @@ export class LangfuseClient {
     });
     span.recordException({ message: input.error });
     span.end(new Date(input.completed));
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
     if (observation) {
       this.rememberToolResult({
         sessionID: observation.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -715,8 +715,8 @@ export class LangfuseClient {
     );
     const step =
       this.traceState.activeGenerationStepsByMessageId.get(input.messageID) ??
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      (activeStep?.messageID === input.messageID || !activeStep?.messageID
+      (activeStep?.messageID === input.messageID ||
+      !(activeStep?.messageID ?? "")
         ? activeStep
         : undefined);
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -165,8 +165,7 @@ export class LangfuseClient {
 
     for (const [messageID, step] of this.traceState
       .activeGenerationStepsByMessageId) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (!sessionID || step.sessionID === sessionID) {
+      if (!(sessionID ?? "") || step.sessionID === sessionID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -204,8 +204,7 @@ export class LangfuseClient {
     sessionID: string;
     parentSessionID?: string;
   }) {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (input.parentSessionID) {
+    if (input.parentSessionID ?? "") {
       this.traceState.sessionParentIds.set(
         input.sessionID,
         input.parentSessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -382,8 +382,7 @@ export class LangfuseClient {
 
     if (
       existingStep &&
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      !(existingStep.messageID != null) &&
+      existingStep.messageID == null &&
       messageID != null
     ) {
       const updatedStep = {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -386,8 +386,7 @@ export class LangfuseClient {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (existingStep && !(existingStep.messageID ?? "") && messageID) {
+    if (existingStep && !(existingStep.messageID ?? "") && (messageID ?? "")) {
       const updatedStep = {
         ...existingStep,
         sessionID: input.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -333,7 +333,7 @@ export class LangfuseClient {
   }) {
     const messageID = input.assistantMessageID;
     const existingMessageStep =
-      (messageID ?? "")
+      messageID != null
         ? this.traceState.activeGenerationStepsByMessageId.get(messageID)
         : undefined;
     const existingStep = this.traceState.activeGenerationSteps.get(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1104,16 +1104,13 @@ export class LangfuseClient {
     });
     span.recordException({ message: input.error });
     span.end(new Date(input.completed));
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions -- Existing violations; fix separately.
-    if (observation) {
-      this.rememberToolResult({
-        sessionID: observation.sessionID,
-        callID: input.callID,
-        tool: input.tool ?? observation.tool,
-        content: input.error,
-        messageID: input.messageID,
-      });
-    }
+    this.rememberToolResult({
+      sessionID: observation.sessionID,
+      callID: input.callID,
+      tool: input.tool ?? observation.tool,
+      content: input.error,
+      messageID: input.messageID,
+    });
     this.traceState.activeToolObservations.delete(input.callID);
     this.traceState.finalizedToolCallIds.add(input.callID);
     this.traceState.toolMessageIdsByCallId.delete(input.callID);

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1073,8 +1073,7 @@ export class LangfuseClient {
     if (
       !this.traceState.activeToolObservations.has(input.callID) &&
       (input.sessionID ?? "") &&
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      input.tool
+      (input.tool ?? "")
     ) {
       this.traceToolStart({
         sessionID: input.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -2,11 +2,7 @@ import { LangfuseSpanProcessor } from "@langfuse/otel";
 import type { Hooks } from "@opencode-ai/plugin";
 import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type { Span as ApiSpan, Tracer } from "@opentelemetry/api";
-import type {
-  ReadableSpan,
-  Span,
-  SpanProcessor,
-} from "@opentelemetry/sdk-trace-base";
+import type { Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import {
   defaultResource,
   detectResources,
@@ -1455,8 +1451,7 @@ const makeAppRootSpanProcessor = (tracerName: string) =>
         span.name === "opencode.turn",
       );
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
-    onEnd: (_span: ReadableSpan) => {},
+    onEnd: () => undefined,
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
   }) satisfies SpanProcessor;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1436,11 +1436,11 @@ const makeUserIdSpanProcessor = (userId: string) =>
 
 const makePluginVersionSpanProcessor = () =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
     onStart: (span: Span, _parentContext: unknown) => {
       span.setAttribute("langfuse.plugin.version", PLUGIN_VERSION);
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1528,8 +1528,9 @@ export const createLangfuseClient = (input: {
     });
     let isShutdown = false;
 
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
-    yield* Effect.sync(() => provider.register());
+    yield* Effect.sync(() => {
+      provider.register();
+    });
 
     return new LangfuseClient({
       baseUrl: input.baseUrl,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -157,8 +157,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, step] of this.traceState
       .activeGenerationSteps) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (!sessionID || step.sessionID === sessionID) {
+      if (!(sessionID ?? "") || step.sessionID === sessionID) {
         this.traceState.activeGenerationSteps.delete(activeSessionID);
         this.traceState.generationParentSpans.delete(activeSessionID);
       }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1210,8 +1210,7 @@ export class LangfuseClient {
     const thinking = parts
       .filter(
         (part): part is Extract<MessagePart, { type: "reasoning" }> =>
-          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-          part.type === "reasoning" && Boolean(part.text),
+          part.type === "reasoning" && part.text !== "",
       )
       .map((part) => ({ type: "thinking" as const, content: part.text }));
     const toolCallsById = new Map(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1447,8 +1447,7 @@ const makePluginVersionSpanProcessor = () =>
 // Langfuse's OTEL processor may auto-mark exported spans as app roots, this overrides that.
 const makeAppRootSpanProcessor = (tracerName: string) =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
-    onStart: (span: Span, _parentContext: unknown) => {
+    onStart: (span: Span) => {
       if (span.instrumentationScope.name !== tracerName) {
         return;
       }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -110,6 +110,7 @@ export class LangfuseClient {
   endActiveToolObservations(sessionID?: string, error?: SessionErrorInfo) {
     for (const [callID, observation] of this.traceState
       .activeToolObservations) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (sessionID && observation.sessionID !== sessionID) {
         continue;
       }
@@ -138,6 +139,7 @@ export class LangfuseClient {
     ]);
 
     for (const step of activeSteps) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (sessionID && step.sessionID !== sessionID) {
         continue;
       }
@@ -157,6 +159,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, step] of this.traceState
       .activeGenerationSteps) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (!sessionID || step.sessionID === sessionID) {
         this.traceState.activeGenerationSteps.delete(activeSessionID);
         this.traceState.generationParentSpans.delete(activeSessionID);
@@ -165,6 +168,7 @@ export class LangfuseClient {
 
     for (const [messageID, step] of this.traceState
       .activeGenerationStepsByMessageId) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (!sessionID || step.sessionID === sessionID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
@@ -178,6 +182,7 @@ export class LangfuseClient {
     ]);
 
     for (const observation of observations) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (sessionID && observation.sessionID !== sessionID) {
         continue;
       }
@@ -187,6 +192,7 @@ export class LangfuseClient {
 
     for (const [messageID, observation] of this.traceState
       .turnObservationsByMessageId) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (!sessionID || observation.sessionID === sessionID) {
         this.traceState.turnObservationsByMessageId.delete(messageID);
       }
@@ -194,6 +200,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, observation] of this.traceState
       .latestTurnObservationsBySession) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (!sessionID || observation.sessionID === sessionID) {
         this.traceState.latestTurnObservationsBySession.delete(activeSessionID);
       }
@@ -204,6 +211,7 @@ export class LangfuseClient {
     sessionID: string;
     parentSessionID?: string;
   }) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (input.parentSessionID) {
       this.traceState.sessionParentIds.set(
         input.sessionID,
@@ -279,6 +287,7 @@ export class LangfuseClient {
 
     this.traceState.tracedReasoningIds.add(reasoningTraceKey);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (!input.messageID) {
       return;
     }
@@ -332,6 +341,7 @@ export class LangfuseClient {
     snapshot?: string;
   }) {
     const messageID = input.assistantMessageID;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     const existingMessageStep = messageID
       ? this.traceState.activeGenerationStepsByMessageId.get(messageID)
       : undefined;
@@ -340,6 +350,7 @@ export class LangfuseClient {
     );
 
     if (
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       messageID &&
       !existingMessageStep &&
       this.traceState.generationSpansByMessageId.has(messageID)
@@ -347,6 +358,7 @@ export class LangfuseClient {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (existingMessageStep && messageID) {
       const updatedStep = {
         ...existingMessageStep,
@@ -385,6 +397,7 @@ export class LangfuseClient {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (existingStep && !existingStep.messageID && messageID) {
       const updatedStep = {
         ...existingStep,
@@ -424,6 +437,7 @@ export class LangfuseClient {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (!messageID && existingStep) {
       return;
     }
@@ -463,6 +477,7 @@ export class LangfuseClient {
         span,
         snapshot: input.snapshot,
       });
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (messageID) {
         const step = this.traceState.activeGenerationSteps.get(input.sessionID);
         if (step) {
@@ -483,6 +498,7 @@ export class LangfuseClient {
     tools?: ToolDefinition[];
   }) {
     if (
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       input.messageID &&
       this.traceState.tracedMessageIds.has(input.messageID)
     ) {
@@ -533,6 +549,7 @@ export class LangfuseClient {
     const generationInput = [
       {
         ...formattedMessage,
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
         ...(input.tools?.length ? { tools: input.tools } : {}),
       },
     ];
@@ -542,6 +559,7 @@ export class LangfuseClient {
       generationInput,
     );
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (input.messageID) {
       this.traceState.tracedMessageIds.add(input.messageID);
     }
@@ -588,6 +606,7 @@ export class LangfuseClient {
         messageID: input.messageID,
       } satisfies TurnObservation;
 
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (input.messageID) {
         this.traceState.turnObservationsByMessageId.set(
           input.messageID,
@@ -714,6 +733,7 @@ export class LangfuseClient {
     );
     const step =
       this.traceState.activeGenerationStepsByMessageId.get(input.messageID) ??
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       (activeStep?.messageID === input.messageID || !activeStep?.messageID
         ? activeStep
         : undefined);
@@ -834,11 +854,13 @@ export class LangfuseClient {
     const activeStep = this.traceState.activeGenerationSteps.get(
       input.sessionID,
     );
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     const step = input.assistantMessageID
       ? (this.traceState.activeGenerationStepsByMessageId.get(
           input.assistantMessageID,
         ) ??
         (activeStep?.messageID === input.assistantMessageID ||
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
         !activeStep?.messageID
           ? activeStep
           : undefined))
@@ -865,6 +887,7 @@ export class LangfuseClient {
       step.span.recordException(input.error);
       step.span.end(new Date(input.completed));
       const messageID = input.assistantMessageID ?? step.messageID;
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (messageID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
@@ -940,6 +963,7 @@ export class LangfuseClient {
 
     turn.span.end();
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (turn.messageID) {
       this.traceState.turnObservationsByMessageId.delete(turn.messageID);
     }
@@ -1069,7 +1093,9 @@ export class LangfuseClient {
 
     if (
       !this.traceState.activeToolObservations.has(input.callID) &&
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       input.sessionID &&
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       input.tool
     ) {
       this.traceToolStart({
@@ -1101,7 +1127,7 @@ export class LangfuseClient {
     });
     span.recordException({ message: input.error });
     span.end(new Date(input.completed));
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions -- Existing violations; fix separately.
     if (observation) {
       this.rememberToolResult({
         sessionID: observation.sessionID,
@@ -1164,6 +1190,7 @@ export class LangfuseClient {
 
   private getTurnObservation(sessionID: string, messageID: string | undefined) {
     return (
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       (messageID
         ? this.traceState.turnObservationsByMessageId.get(messageID)
         : undefined) ??
@@ -1174,6 +1201,7 @@ export class LangfuseClient {
   private getSessionParentSpan(sessionID: string) {
     const parentSessionID = this.traceState.sessionParentIds.get(sessionID);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (!parentSessionID) {
       return undefined;
     }
@@ -1191,6 +1219,7 @@ export class LangfuseClient {
     messageID?: string,
   ) {
     const parentSpan =
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       (messageID
         ? this.traceState.generationSpansByMessageId.get(messageID)
         : undefined) ??
@@ -1254,6 +1283,7 @@ export class LangfuseClient {
     this.traceState.generationInputsBySession.delete(sessionID);
     this.traceState.toolResultSourceMessageIdsBySession.delete(sessionID);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (!sourceMessageID) {
       return input;
     }
@@ -1284,6 +1314,7 @@ export class LangfuseClient {
     });
     this.traceState.generationInputsBySession.set(input.sessionID, toolResults);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (messageID) {
       this.traceState.toolResultSourceMessageIdsBySession.set(
         input.sessionID,
@@ -1299,7 +1330,7 @@ export class LangfuseClient {
 
     if (
       "data" in error &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions -- Existing violations; fix separately.
       error.data &&
       typeof error.data === "object" &&
       "message" in error.data &&
@@ -1515,12 +1546,14 @@ export const createLangfuseClient = (input: {
       resource: defaultResource()
         .merge(detectResources({ detectors: [envDetector] }))
         .merge(
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
           input.serviceName
             ? resourceFromAttributes({ "service.name": input.serviceName })
             : null,
         ),
       spanProcessors: [
         makePluginVersionSpanProcessor(),
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
         ...(input.userId ? [makeUserIdSpanProcessor(input.userId)] : []),
         processor,
         makeAppRootSpanProcessor(traceState.tracerName),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1076,8 +1076,8 @@ export class LangfuseClient {
 
     if (
       !this.traceState.activeToolObservations.has(input.callID) &&
-      (input.sessionID ?? "") &&
-      (input.tool ?? "")
+      input.sessionID != null &&
+      input.tool != null
     ) {
       this.traceToolStart({
         sessionID: input.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -204,7 +204,7 @@ export class LangfuseClient {
     sessionID: string;
     parentSessionID?: string;
   }) {
-    if (input.parentSessionID ?? "") {
+    if (input.parentSessionID != null) {
       this.traceState.sessionParentIds.set(
         input.sessionID,
         input.parentSessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -183,8 +183,7 @@ export class LangfuseClient {
 
     for (const [messageID, observation] of this.traceState
       .turnObservationsByMessageId) {
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      if (!(sessionID != null) || observation.sessionID === sessionID) {
+      if (sessionID == null || observation.sessionID === sessionID) {
         this.traceState.turnObservationsByMessageId.delete(messageID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1518,8 +1518,7 @@ export const createLangfuseClient = (input: {
       resource: defaultResource()
         .merge(detectResources({ detectors: [envDetector] }))
         .merge(
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-          input.serviceName
+          (input.serviceName ?? "")
             ? resourceFromAttributes({ "service.name": input.serviceName })
             : null,
         ),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -841,12 +841,12 @@ export class LangfuseClient {
       input.sessionID,
     );
     const step =
-      (input.assistantMessageID ?? "")
+      input.assistantMessageID != null
         ? (this.traceState.activeGenerationStepsByMessageId.get(
             input.assistantMessageID,
           ) ??
           (activeStep?.messageID === input.assistantMessageID ||
-          !(activeStep?.messageID ?? "")
+          !(activeStep?.messageID != null)
             ? activeStep
             : undefined))
         : activeStep;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -495,7 +495,7 @@ export class LangfuseClient {
       role: "user" as const,
       content: input.parts.map((part) => {
         if (part.type === "text") {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
           return { type: part.type, text: part.text ?? "" };
         }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -153,8 +153,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, step] of this.traceState
       .activeGenerationSteps) {
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      if (!(sessionID != null) || step.sessionID === sessionID) {
+      if (sessionID == null || step.sessionID === sessionID) {
         this.traceState.activeGenerationSteps.delete(activeSessionID);
         this.traceState.generationParentSpans.delete(activeSessionID);
       }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1299,7 +1299,7 @@ export class LangfuseClient {
 
     if (
       "data" in error &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
       error.data &&
       typeof error.data === "object" &&
       "message" in error.data &&

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1167,8 +1167,7 @@ export class LangfuseClient {
 
   private getTurnObservation(sessionID: string, messageID: string | undefined) {
     return (
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      (messageID
+      ((messageID ?? "")
         ? this.traceState.turnObservationsByMessageId.get(messageID)
         : undefined) ??
       this.traceState.latestTurnObservationsBySession.get(sessionID)

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -498,8 +498,7 @@ export class LangfuseClient {
       role: "user" as const,
       content: input.parts.map((part) => {
         if (part.type === "text") {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
-          return { type: part.type, text: part.text ?? "" };
+          return { type: part.type, text: part.text };
         }
 
         if (part.type === "file") {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -593,7 +593,7 @@ export class LangfuseClient {
         messageID: input.messageID,
       } satisfies TurnObservation;
 
-      if (input.messageID ?? "") {
+      if (input.messageID != null) {
         this.traceState.turnObservationsByMessageId.set(
           input.messageID,
           observation,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1424,8 +1424,7 @@ export class LangfuseClientService extends EffectContext.Tag(
 
 const makeUserIdSpanProcessor = (userId: string) =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
-    onStart: (span: Span, _parentContext: unknown) => {
+    onStart: (span: Span) => {
       span.setAttribute("langfuse.user.id", userId);
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -106,8 +106,7 @@ export class LangfuseClient {
   endActiveToolObservations(sessionID?: string, error?: SessionErrorInfo) {
     for (const [callID, observation] of this.traceState
       .activeToolObservations) {
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      if (Boolean(sessionID) && observation.sessionID !== sessionID) {
+      if (sessionID != null && observation.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -468,7 +468,7 @@ export class LangfuseClient {
         span,
         snapshot: input.snapshot,
       });
-      if (messageID ?? "") {
+      if (messageID != null) {
         const step = this.traceState.activeGenerationSteps.get(input.sessionID);
         if (step) {
           this.traceState.activeGenerationStepsByMessageId.set(messageID, step);

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -947,7 +947,7 @@ export class LangfuseClient {
 
     turn.span.end();
 
-    if (turn.messageID ?? "") {
+    if (turn.messageID != null) {
       this.traceState.turnObservationsByMessageId.delete(turn.messageID);
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1524,8 +1524,9 @@ export const createLangfuseClient = (input: {
         ),
       spanProcessors: [
         makePluginVersionSpanProcessor(),
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-        ...(input.userId ? [makeUserIdSpanProcessor(input.userId)] : []),
+        ...((input.userId ?? "")
+          ? [makeUserIdSpanProcessor(input.userId)]
+          : []),
         processor,
         makeAppRootSpanProcessor(traceState.tracerName),
       ],

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1203,8 +1203,7 @@ export class LangfuseClient {
     const content = parts
       .filter(
         (part): part is Extract<MessagePart, { type: "text" }> =>
-          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-          part.type === "text" && Boolean(part.text),
+          part.type === "text" && part.text !== "",
       )
       .map((part) => part.text)
       .join("");

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1257,8 +1257,7 @@ export class LangfuseClient {
     this.traceState.generationInputsBySession.delete(sessionID);
     this.traceState.toolResultSourceMessageIdsBySession.delete(sessionID);
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (!sourceMessageID) {
+    if (!(sourceMessageID ?? "")) {
       return input;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -538,7 +538,7 @@ export class LangfuseClient {
     const generationInput = [
       {
         ...formattedMessage,
-        ...((input.tools?.length ?? 0) ? { tools: input.tools } : {}),
+        ...((input.tools?.length ?? 0) > 0 ? { tools: input.tools } : {}),
       },
     ];
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -484,8 +484,7 @@ export class LangfuseClient {
     tools?: ToolDefinition[];
   }) {
     if (
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      input.messageID &&
+      (input.messageID ?? "") &&
       this.traceState.tracedMessageIds.has(input.messageID)
     ) {
       return;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -157,7 +157,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, step] of this.traceState
       .activeGenerationSteps) {
-      if (!(sessionID ?? "") || step.sessionID === sessionID) {
+      if (!(sessionID != null) || step.sessionID === sessionID) {
         this.traceState.activeGenerationSteps.delete(activeSessionID);
         this.traceState.generationParentSpans.delete(activeSessionID);
       }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -868,8 +868,7 @@ export class LangfuseClient {
       step.span.recordException(input.error);
       step.span.end(new Date(input.completed));
       const messageID = input.assistantMessageID ?? step.messageID;
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (messageID) {
+      if (messageID ?? "") {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -194,8 +194,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, observation] of this.traceState
       .latestTurnObservationsBySession) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (!sessionID || observation.sessionID === sessionID) {
+      if (!(sessionID ?? "") || observation.sessionID === sessionID) {
         this.traceState.latestTurnObservationsBySession.delete(activeSessionID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1435,8 +1435,7 @@ const makeUserIdSpanProcessor = (userId: string) =>
 
 const makePluginVersionSpanProcessor = () =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
-    onStart: (span: Span, _parentContext: unknown) => {
+    onStart: (span: Span) => {
       span.setAttribute("langfuse.plugin.version", PLUGIN_VERSION);
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -425,8 +425,7 @@ export class LangfuseClient {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (!messageID && existingStep) {
+    if (!(messageID ?? "") && existingStep) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1427,8 +1427,7 @@ const makeUserIdSpanProcessor = (userId: string) =>
     onStart: (span: Span) => {
       span.setAttribute("langfuse.user.id", userId);
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
-    onEnd: (_span: ReadableSpan) => {},
+    onEnd: () => undefined,
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
   }) satisfies SpanProcessor;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1194,8 +1194,7 @@ export class LangfuseClient {
     messageID?: string,
   ) {
     const parentSpan =
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      (messageID
+      ((messageID ?? "")
         ? this.traceState.generationSpansByMessageId.get(messageID)
         : undefined) ??
       this.traceState.activeGenerationSteps.get(sessionID)?.span ??

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -423,8 +423,7 @@ export class LangfuseClient {
       return;
     }
 
-    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-    if (!(messageID != null) && existingStep) {
+    if (messageID == null && existingStep) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1517,13 +1517,13 @@ export const createLangfuseClient = (input: {
       resource: defaultResource()
         .merge(detectResources({ detectors: [envDetector] }))
         .merge(
-          (input.serviceName ?? "")
+          input.serviceName != null
             ? resourceFromAttributes({ "service.name": input.serviceName })
             : null,
         ),
       spanProcessors: [
         makePluginVersionSpanProcessor(),
-        ...((input.userId ?? "")
+        ...(input.userId != null
           ? [makeUserIdSpanProcessor(input.userId)]
           : []),
         processor,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -279,8 +279,7 @@ export class LangfuseClient {
 
     this.traceState.tracedReasoningIds.add(reasoningTraceKey);
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (!input.messageID) {
+    if (!(input.messageID ?? "")) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -178,7 +178,7 @@ export class LangfuseClient {
     ]);
 
     for (const observation of observations) {
-      if ((sessionID ?? "") && observation.sessionID !== sessionID) {
+      if (sessionID != null && observation.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -547,7 +547,7 @@ export class LangfuseClient {
       generationInput,
     );
 
-    if (input.messageID ?? "") {
+    if (input.messageID != null) {
       this.traceState.tracedMessageIds.add(input.messageID);
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1437,8 +1437,7 @@ const makePluginVersionSpanProcessor = () =>
     onStart: (span: Span) => {
       span.setAttribute("langfuse.plugin.version", PLUGIN_VERSION);
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
-    onEnd: (_span: ReadableSpan) => {},
+    onEnd: () => undefined,
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
   }) satisfies SpanProcessor;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -720,7 +720,7 @@ export class LangfuseClient {
     const step =
       this.traceState.activeGenerationStepsByMessageId.get(input.messageID) ??
       (activeStep?.messageID === input.messageID ||
-      !(activeStep?.messageID ?? "")
+      !(activeStep?.messageID != null)
         ? activeStep
         : undefined);
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -380,11 +380,7 @@ export class LangfuseClient {
       return;
     }
 
-    if (
-      existingStep &&
-      existingStep.messageID == null &&
-      messageID != null
-    ) {
+    if (existingStep && existingStep.messageID == null && messageID != null) {
       const updatedStep = {
         ...existingStep,
         sessionID: input.sessionID,
@@ -714,8 +710,7 @@ export class LangfuseClient {
     const step =
       this.traceState.activeGenerationStepsByMessageId.get(input.messageID) ??
       (activeStep?.messageID === input.messageID ||
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      !(activeStep?.messageID != null)
+      activeStep?.messageID == null
         ? activeStep
         : undefined);
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1299,8 +1299,6 @@ export class LangfuseClient {
 
     if (
       "data" in error &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions -- Existing violations; fix separately.
-      error.data &&
       typeof error.data === "object" &&
       "message" in error.data &&
       typeof error.data.message === "string"

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -366,7 +366,9 @@ export class LangfuseClient {
         "langfuse.observation.metadata",
         JSON.stringify({
           agent: updatedStep.agent,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
           providerID: updatedStep.model?.providerID,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
           variant: updatedStep.model?.variant,
           snapshot: updatedStep.snapshot,
         }),
@@ -493,6 +495,7 @@ export class LangfuseClient {
       role: "user" as const,
       content: input.parts.map((part) => {
         if (part.type === "text") {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
           return { type: part.type, text: part.text ?? "" };
         }
 
@@ -620,6 +623,7 @@ export class LangfuseClient {
       });
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation; fix separately.
     parentSpan
       ? context.with(trace.setSpan(context.active(), parentSpan), startTurn)
       : startTurn();
@@ -1097,6 +1101,7 @@ export class LangfuseClient {
     });
     span.recordException({ message: input.error });
     span.end(new Date(input.completed));
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
     if (observation) {
       this.rememberToolResult({
         sessionID: observation.sessionID,
@@ -1294,6 +1299,7 @@ export class LangfuseClient {
 
     if (
       "data" in error &&
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
       error.data &&
       typeof error.data === "object" &&
       "message" in error.data &&
@@ -1418,9 +1424,11 @@ export class LangfuseClientService extends EffectContext.Tag(
 
 const makeUserIdSpanProcessor = (userId: string) =>
   ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
     onStart: (span: Span, _parentContext: unknown) => {
       span.setAttribute("langfuse.user.id", userId);
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
@@ -1428,9 +1436,11 @@ const makeUserIdSpanProcessor = (userId: string) =>
 
 const makePluginVersionSpanProcessor = () =>
   ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
     onStart: (span: Span, _parentContext: unknown) => {
       span.setAttribute("langfuse.plugin.version", PLUGIN_VERSION);
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
@@ -1439,6 +1449,7 @@ const makePluginVersionSpanProcessor = () =>
 // Langfuse's OTEL processor may auto-mark exported spans as app roots, this overrides that.
 const makeAppRootSpanProcessor = (tracerName: string) =>
   ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
     onStart: (span: Span, _parentContext: unknown) => {
       if (span.instrumentationScope.name !== tracerName) {
         return;
@@ -1449,6 +1460,7 @@ const makeAppRootSpanProcessor = (tracerName: string) =>
         span.name === "opencode.turn",
       );
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),
@@ -1516,6 +1528,7 @@ export const createLangfuseClient = (input: {
     });
     let isShutdown = false;
 
+    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
     yield* Effect.sync(() => provider.register());
 
     return new LangfuseClient({

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -178,8 +178,7 @@ export class LangfuseClient {
     ]);
 
     for (const observation of observations) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (sessionID && observation.sessionID !== sessionID) {
+      if ((sessionID ?? "") && observation.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -872,7 +872,7 @@ export class LangfuseClient {
       step.span.recordException(input.error);
       step.span.end(new Date(input.completed));
       const messageID = input.assistantMessageID ?? step.messageID;
-      if (messageID ?? "") {
+      if (messageID != null) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -836,8 +836,7 @@ export class LangfuseClient {
             input.assistantMessageID,
           ) ??
           (activeStep?.messageID === input.assistantMessageID ||
-          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-          !(activeStep?.messageID != null)
+          activeStep?.messageID == null
             ? activeStep
             : undefined))
         : activeStep;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1248,8 +1248,7 @@ export class LangfuseClient {
     this.traceState.generationInputsBySession.delete(sessionID);
     this.traceState.toolResultSourceMessageIdsBySession.delete(sessionID);
 
-    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-    if (!(sourceMessageID != null)) {
+    if (sourceMessageID == null) {
       return input;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -110,8 +110,7 @@ export class LangfuseClient {
   endActiveToolObservations(sessionID?: string, error?: SessionErrorInfo) {
     for (const [callID, observation] of this.traceState
       .activeToolObservations) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (sessionID && observation.sessionID !== sessionID) {
+      if (Boolean(sessionID) && observation.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -625,10 +625,11 @@ export class LangfuseClient {
       });
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
-    parentSpan
-      ? context.with(trace.setSpan(context.active(), parentSpan), startTurn)
-      : startTurn();
+    if (parentSpan) {
+      context.with(trace.setSpan(context.active(), parentSpan), startTurn);
+    } else {
+      startTurn();
+    }
   }
 
   rememberAssistantPart(part: MessagePart) {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -332,10 +332,10 @@ export class LangfuseClient {
     snapshot?: string;
   }) {
     const messageID = input.assistantMessageID;
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    const existingMessageStep = messageID
-      ? this.traceState.activeGenerationStepsByMessageId.get(messageID)
-      : undefined;
+    const existingMessageStep =
+      (messageID ?? "")
+        ? this.traceState.activeGenerationStepsByMessageId.get(messageID)
+        : undefined;
     const existingStep = this.traceState.activeGenerationSteps.get(
       input.sessionID,
     );

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -534,8 +534,7 @@ export class LangfuseClient {
     const generationInput = [
       {
         ...formattedMessage,
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-        ...(input.tools?.length ? { tools: input.tools } : {}),
+        ...((input.tools?.length ?? 0) ? { tools: input.tools } : {}),
       },
     ];
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -943,8 +943,7 @@ export class LangfuseClient {
 
     turn.span.end();
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (turn.messageID) {
+    if (turn.messageID ?? "") {
       this.traceState.turnObservationsByMessageId.delete(turn.messageID);
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1424,11 +1424,11 @@ export class LangfuseClientService extends EffectContext.Tag(
 
 const makeUserIdSpanProcessor = (userId: string) =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
     onStart: (span: Span, _parentContext: unknown) => {
       span.setAttribute("langfuse.user.id", userId);
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -366,9 +366,9 @@ export class LangfuseClient {
         "langfuse.observation.metadata",
         JSON.stringify({
           agent: updatedStep.agent,
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
           providerID: updatedStep.model?.providerID,
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
           variant: updatedStep.model?.variant,
           snapshot: updatedStep.snapshot,
         }),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -161,8 +161,7 @@ export class LangfuseClient {
 
     for (const [messageID, step] of this.traceState
       .activeGenerationStepsByMessageId) {
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      if (!(sessionID != null) || step.sessionID === sessionID) {
+      if (sessionID == null || step.sessionID === sessionID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -386,7 +386,11 @@ export class LangfuseClient {
       return;
     }
 
-    if (existingStep && !(existingStep.messageID ?? "") && (messageID ?? "")) {
+    if (
+      existingStep &&
+      !(existingStep.messageID != null) &&
+      messageID != null
+    ) {
       const updatedStep = {
         ...existingStep,
         sessionID: input.sessionID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -279,7 +279,7 @@ export class LangfuseClient {
 
     this.traceState.tracedReasoningIds.add(reasoningTraceKey);
 
-    if (!(input.messageID ?? "")) {
+    if (!(input.messageID != null)) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -106,6 +106,7 @@ export class LangfuseClient {
   endActiveToolObservations(sessionID?: string, error?: SessionErrorInfo) {
     for (const [callID, observation] of this.traceState
       .activeToolObservations) {
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       if (Boolean(sessionID) && observation.sessionID !== sessionID) {
         continue;
       }
@@ -153,6 +154,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, step] of this.traceState
       .activeGenerationSteps) {
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       if (!(sessionID != null) || step.sessionID === sessionID) {
         this.traceState.activeGenerationSteps.delete(activeSessionID);
         this.traceState.generationParentSpans.delete(activeSessionID);
@@ -161,6 +163,7 @@ export class LangfuseClient {
 
     for (const [messageID, step] of this.traceState
       .activeGenerationStepsByMessageId) {
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       if (!(sessionID != null) || step.sessionID === sessionID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
@@ -183,6 +186,7 @@ export class LangfuseClient {
 
     for (const [messageID, observation] of this.traceState
       .turnObservationsByMessageId) {
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       if (!(sessionID != null) || observation.sessionID === sessionID) {
         this.traceState.turnObservationsByMessageId.delete(messageID);
       }
@@ -190,6 +194,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, observation] of this.traceState
       .latestTurnObservationsBySession) {
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       if (!(sessionID != null) || observation.sessionID === sessionID) {
         this.traceState.latestTurnObservationsBySession.delete(activeSessionID);
       }
@@ -275,6 +280,7 @@ export class LangfuseClient {
 
     this.traceState.tracedReasoningIds.add(reasoningTraceKey);
 
+    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
     if (!(input.messageID != null)) {
       return;
     }
@@ -382,6 +388,7 @@ export class LangfuseClient {
 
     if (
       existingStep &&
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       !(existingStep.messageID != null) &&
       messageID != null
     ) {
@@ -423,6 +430,7 @@ export class LangfuseClient {
       return;
     }
 
+    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
     if (!(messageID != null) && existingStep) {
       return;
     }
@@ -714,6 +722,7 @@ export class LangfuseClient {
     const step =
       this.traceState.activeGenerationStepsByMessageId.get(input.messageID) ??
       (activeStep?.messageID === input.messageID ||
+      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
       !(activeStep?.messageID != null)
         ? activeStep
         : undefined);
@@ -840,6 +849,7 @@ export class LangfuseClient {
             input.assistantMessageID,
           ) ??
           (activeStep?.messageID === input.assistantMessageID ||
+          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
           !(activeStep?.messageID != null)
             ? activeStep
             : undefined))
@@ -1172,6 +1182,7 @@ export class LangfuseClient {
   private getSessionParentSpan(sessionID: string) {
     const parentSessionID = this.traceState.sessionParentIds.get(sessionID);
 
+    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
     if (!(parentSessionID != null)) {
       return undefined;
     }
@@ -1207,6 +1218,7 @@ export class LangfuseClient {
     const content = parts
       .filter(
         (part): part is Extract<MessagePart, { type: "text" }> =>
+          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
           part.type === "text" && Boolean(part.text),
       )
       .map((part) => part.text)
@@ -1214,6 +1226,7 @@ export class LangfuseClient {
     const thinking = parts
       .filter(
         (part): part is Extract<MessagePart, { type: "reasoning" }> =>
+          // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
           part.type === "reasoning" && Boolean(part.text),
       )
       .map((part) => ({ type: "thinking" as const, content: part.text }));
@@ -1252,6 +1265,7 @@ export class LangfuseClient {
     this.traceState.generationInputsBySession.delete(sessionID);
     this.traceState.toolResultSourceMessageIdsBySession.delete(sessionID);
 
+    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
     if (!(sourceMessageID != null)) {
       return input;
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1168,8 +1168,7 @@ export class LangfuseClient {
   private getSessionParentSpan(sessionID: string) {
     const parentSessionID = this.traceState.sessionParentIds.get(sessionID);
 
-    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-    if (!(parentSessionID != null)) {
+    if (parentSessionID == null) {
       return undefined;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -190,8 +190,7 @@ export class LangfuseClient {
 
     for (const [activeSessionID, observation] of this.traceState
       .latestTurnObservationsBySession) {
-      // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-      if (!(sessionID != null) || observation.sessionID === sessionID) {
+      if (sessionID == null || observation.sessionID === sessionID) {
         this.traceState.latestTurnObservationsBySession.delete(activeSessionID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1195,7 +1195,7 @@ export class LangfuseClient {
     messageID?: string,
   ) {
     const parentSpan =
-      ((messageID ?? "")
+      (messageID != null
         ? this.traceState.generationSpansByMessageId.get(messageID)
         : undefined) ??
       this.traceState.activeGenerationSteps.get(sessionID)?.span ??

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1460,7 +1460,7 @@ const makeAppRootSpanProcessor = (tracerName: string) =>
         span.name === "opencode.turn",
       );
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function -- Existing violation tracked for incremental cleanup.
     onEnd: (_span: ReadableSpan) => {},
     shutdown: () => Promise.resolve(),
     forceFlush: () => Promise.resolve(),

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -138,7 +138,7 @@ export class LangfuseClient {
     ]);
 
     for (const step of activeSteps) {
-      if ((sessionID ?? "") && step.sessionID !== sessionID) {
+      if (sessionID != null && step.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -623,7 +623,7 @@ export class LangfuseClient {
       });
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
     parentSpan
       ? context.with(trace.setSpan(context.active(), parentSpan), startTurn)
       : startTurn();

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1072,8 +1072,7 @@ export class LangfuseClient {
 
     if (
       !this.traceState.activeToolObservations.has(input.callID) &&
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      input.sessionID &&
+      (input.sessionID ?? "") &&
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       input.tool
     ) {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1258,7 +1258,7 @@ export class LangfuseClient {
     this.traceState.generationInputsBySession.delete(sessionID);
     this.traceState.toolResultSourceMessageIdsBySession.delete(sessionID);
 
-    if (!(sourceMessageID ?? "")) {
+    if (!(sourceMessageID != null)) {
       return input;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1177,8 +1177,7 @@ export class LangfuseClient {
   private getSessionParentSpan(sessionID: string) {
     const parentSessionID = this.traceState.sessionParentIds.get(sessionID);
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (!parentSessionID) {
+    if (!(parentSessionID ?? "")) {
       return undefined;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -187,8 +187,7 @@ export class LangfuseClient {
 
     for (const [messageID, observation] of this.traceState
       .turnObservationsByMessageId) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (!sessionID || observation.sessionID === sessionID) {
+      if (!(sessionID ?? "") || observation.sessionID === sessionID) {
         this.traceState.turnObservationsByMessageId.delete(messageID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -543,8 +543,7 @@ export class LangfuseClient {
       generationInput,
     );
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (input.messageID) {
+    if (input.messageID ?? "") {
       this.traceState.tracedMessageIds.add(input.messageID);
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -429,7 +429,7 @@ export class LangfuseClient {
       return;
     }
 
-    if (!(messageID ?? "") && existingStep) {
+    if (!(messageID != null) && existingStep) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -187,14 +187,14 @@ export class LangfuseClient {
 
     for (const [messageID, observation] of this.traceState
       .turnObservationsByMessageId) {
-      if (!(sessionID ?? "") || observation.sessionID === sessionID) {
+      if (!(sessionID != null) || observation.sessionID === sessionID) {
         this.traceState.turnObservationsByMessageId.delete(messageID);
       }
     }
 
     for (const [activeSessionID, observation] of this.traceState
       .latestTurnObservationsBySession) {
-      if (!(sessionID ?? "") || observation.sessionID === sessionID) {
+      if (!(sessionID != null) || observation.sessionID === sessionID) {
         this.traceState.latestTurnObservationsBySession.delete(activeSessionID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -165,7 +165,7 @@ export class LangfuseClient {
 
     for (const [messageID, step] of this.traceState
       .activeGenerationStepsByMessageId) {
-      if (!(sessionID ?? "") || step.sessionID === sessionID) {
+      if (!(sessionID != null) || step.sessionID === sessionID) {
         this.traceState.activeGenerationStepsByMessageId.delete(messageID);
       }
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -138,8 +138,7 @@ export class LangfuseClient {
     ]);
 
     for (const step of activeSteps) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (sessionID && step.sessionID !== sessionID) {
+      if ((sessionID ?? "") && step.sessionID !== sessionID) {
         continue;
       }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -488,7 +488,7 @@ export class LangfuseClient {
     tools?: ToolDefinition[];
   }) {
     if (
-      (input.messageID ?? "") &&
+      input.messageID != null &&
       this.traceState.tracedMessageIds.has(input.messageID)
     ) {
       return;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -348,8 +348,7 @@ export class LangfuseClient {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (existingMessageStep && messageID) {
+    if (existingMessageStep && (messageID ?? "")) {
       const updatedStep = {
         ...existingMessageStep,
         agent: input.agent,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -368,8 +368,7 @@ export class LangfuseClient {
         JSON.stringify({
           agent: updatedStep.agent,
           providerID: updatedStep.model.providerID,
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
-          variant: updatedStep.model?.variant,
+          variant: updatedStep.model.variant,
           snapshot: updatedStep.snapshot,
         }),
       );

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -367,8 +367,7 @@ export class LangfuseClient {
         "langfuse.observation.metadata",
         JSON.stringify({
           agent: updatedStep.agent,
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
-          providerID: updatedStep.model?.providerID,
+          providerID: updatedStep.model.providerID,
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Existing violation tracked for incremental cleanup.
           variant: updatedStep.model?.variant,
           snapshot: updatedStep.snapshot,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1348,7 +1348,7 @@ function getCompletedReasoningTimestamp(part: MessagePart) {
   return undefined;
 }
 
-export type FormattedMessagePart =
+type FormattedMessagePart =
   | { type: string; text: string }
   | { type: string; filename?: string; url?: string }
   | { type: string; name?: string }
@@ -1356,14 +1356,14 @@ export type FormattedMessagePart =
   | { type: string; tool?: string; title?: string }
   | { type: string };
 
-export type SessionError = Extract<
+type SessionError = Extract<
   Parameters<NonNullable<Hooks["event"]>>[0]["event"],
   { type: "session.error" }
 >["properties"]["error"];
 
 export type SessionErrorInfo = NonNullable<SessionError>;
 
-export type UserMessageInput = {
+type UserMessageInput = {
   role: "user";
   content: FormattedMessagePart[];
   tools?: ToolDefinition[];

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1287,8 +1287,7 @@ export class LangfuseClient {
     });
     this.traceState.generationInputsBySession.set(input.sessionID, toolResults);
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (messageID) {
+    if (messageID ?? "") {
       this.traceState.toolResultSourceMessageIdsBySession.set(
         input.sessionID,
         messageID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -341,14 +341,14 @@ export class LangfuseClient {
     );
 
     if (
-      (messageID ?? "") &&
+      messageID != null &&
       !existingMessageStep &&
       this.traceState.generationSpansByMessageId.has(messageID)
     ) {
       return;
     }
 
-    if (existingMessageStep && (messageID ?? "")) {
+    if (existingMessageStep && messageID != null) {
       const updatedStep = {
         ...existingMessageStep,
         agent: input.agent,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -275,8 +275,7 @@ export class LangfuseClient {
 
     this.traceState.tracedReasoningIds.add(reasoningTraceKey);
 
-    // eslint-disable-next-line no-restricted-syntax -- Existing restricted syntax; fix separately.
-    if (!(input.messageID != null)) {
+    if (input.messageID == null) {
       return;
     }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1449,7 +1449,7 @@ const makePluginVersionSpanProcessor = () =>
 // Langfuse's OTEL processor may auto-mark exported spans as app roots, this overrides that.
 const makeAppRootSpanProcessor = (tracerName: string) =>
   ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Existing violation tracked for incremental cleanup.
     onStart: (span: Span, _parentContext: unknown) => {
       if (span.instrumentationScope.name !== tracerName) {
         return;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1288,7 +1288,7 @@ export class LangfuseClient {
     });
     this.traceState.generationInputsBySession.set(input.sessionID, toolResults);
 
-    if (messageID ?? "") {
+    if (messageID != null) {
       this.traceState.toolResultSourceMessageIdsBySession.set(
         input.sessionID,
         messageID,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -341,8 +341,7 @@ export class LangfuseClient {
     );
 
     if (
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      messageID &&
+      (messageID ?? "") &&
       !existingMessageStep &&
       this.traceState.generationSpansByMessageId.has(messageID)
     ) {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -464,8 +464,7 @@ export class LangfuseClient {
         span,
         snapshot: input.snapshot,
       });
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (messageID) {
+      if (messageID ?? "") {
         const step = this.traceState.activeGenerationSteps.get(input.sessionID);
         if (step) {
           this.traceState.activeGenerationStepsByMessageId.set(messageID, step);

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1168,7 +1168,7 @@ export class LangfuseClient {
 
   private getTurnObservation(sessionID: string, messageID: string | undefined) {
     return (
-      ((messageID ?? "")
+      (messageID != null
         ? this.traceState.turnObservationsByMessageId.get(messageID)
         : undefined) ??
       this.traceState.latestTurnObservationsBySession.get(sessionID)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ export const log = (level: "info" | "warn" | "error", message: string) =>
   Effect.gen(function* () {
     const opencode = yield* OpencodeClientService;
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- Existing violation; fix separately.
     yield* Effect.sync(() =>
       opencode.app.log({
         body: { service: "langfuse", level, message },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,7 @@ export const log = (level: "info" | "warn" | "error", message: string) =>
   Effect.gen(function* () {
     const opencode = yield* OpencodeClientService;
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- Existing violation tracked for incremental cleanup.
-    yield* Effect.sync(() =>
+    yield* Effect.tryPromise(() =>
       opencode.app.log({
         body: { service: "langfuse", level, message },
       }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export const log = (level: "info" | "warn" | "error", message: string) =>
   Effect.gen(function* () {
     const opencode = yield* OpencodeClientService;
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- Existing violation tracked for incremental cleanup.
     yield* Effect.sync(() =>
       opencode.app.log({
         body: { service: "langfuse", level, message },

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -338,8 +338,7 @@ const completeGeneration = async (input: {
   completed: number;
   text?: string;
 }) => {
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-  if (input.text) {
+  if (input.text ?? "") {
     await emitEvent({
       type: "message.part.updated",
       properties: {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -484,7 +484,9 @@ beforeAll(async () => {
   process.env.LANGFUSE_USER_ID = "test-user";
   delete process.env.LANGFUSE_BASEURL;
 
-  ({ default: plugin } = await import("../../dist/index.js"));
+  const builtPluginUrl = new URL("../../dist/index.js", import.meta.url);
+  const builtPlugin: unknown = await import(builtPluginUrl.href);
+  plugin = (builtPlugin as { default: Plugin }).default;
 });
 
 beforeEach(async () => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -538,8 +538,7 @@ beforeAll(async () => {
 
   process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
   process.env.LANGFUSE_SECRET_KEY = "sk-test";
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-  collectorBaseUrl = `http://127.0.0.1:${address.port}`;
+  collectorBaseUrl = `http://127.0.0.1:${address.port.toString()}`;
   process.env.LANGFUSE_BASE_URL = collectorBaseUrl;
   process.env.LANGFUSE_ENVIRONMENT = "integration-test";
   process.env.LANGFUSE_USER_ID = "test-user";

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1637,8 +1637,7 @@ describe.sequential("built plugin", () => {
 
     const spanIds = new Set(spans.map((span) => span.spanId));
     for (const span of spans) {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-      if (span.parentSpanId) {
+      if (span.parentSpanId ?? "") {
         expect(spanIds.has(span.parentSpanId)).toBe(true);
       }
     }

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1158,8 +1158,7 @@ describe("built plugin", { concurrent: false }, () => {
     const userMessageID = "out-of-order-tool-parenting-user";
     const started = startedAt;
     const generations = [1, 2, 3].map((index) => ({
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-      assistantMessageID: `out-of-order-tool-parenting-assistant-${index}`,
+      assistantMessageID: `out-of-order-tool-parenting-assistant-${index.toString()}`,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       stepID: `out-of-order-tool-parenting-step-${index}`,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -63,7 +63,7 @@ type CapturedRequest = {
   body: typeof CapturedRequestBodySchema.Type;
 };
 
-type Plugin = (typeof import("../../dist/index.js"))["default"];
+type Plugin = (typeof import("../../src/index.js"))["default"];
 type PluginHooks = Awaited<ReturnType<Plugin>>;
 type PluginEvent = Parameters<NonNullable<PluginHooks["event"]>>[0]["event"];
 type SessionNextEvent =

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -127,6 +127,7 @@ type TestPluginEvent =
       };
     };
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
 const packageJson = JSON.parse(
   readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
 ) as { version?: unknown };
@@ -189,6 +190,7 @@ const getJsonAttribute = (span: OtlpSpan, key: string) => {
     throw new Error(`Expected ${span.name} attribute ${key} to be JSON`);
   }
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   return JSON.parse(value) as unknown;
 };
 
@@ -222,6 +224,7 @@ const getSessionSpan = (spans: OtlpSpan[], name: string, sessionID: string) => {
 const emitEvent = async (event: TestPluginEvent) => {
   // These events are emitted by current OpenCode versions but are not yet part of
   // the PluginEvent union exported by our pinned @opencode-ai/plugin version.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   await hooks.event?.({ event: event as PluginEvent });
 };
 
@@ -381,6 +384,7 @@ const completeGeneration = async (input: {
 
 const createHooks = async (baseUrl: string) => {
   process.env.LANGFUSE_BASE_URL = baseUrl;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   const client = {
     app: {
       log: () => Promise.resolve(),
@@ -419,6 +423,7 @@ const createHooks = async (baseUrl: string) => {
     },
   } as unknown as Parameters<Plugin>[0]["client"];
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   return plugin({ client } as Parameters<Plugin>[0]);
 };
 
@@ -451,6 +456,7 @@ beforeAll(async () => {
           method: request.method,
           url: request.url,
           headers: request.headers,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
           body: JSON.parse(
             Buffer.concat(chunks).toString("utf8"),
           ) as CapturedRequest["body"],
@@ -490,6 +496,7 @@ beforeAll(async () => {
 
   const builtPluginUrl = new URL("../../dist/index.js", import.meta.url);
   const builtPlugin: unknown = await import(builtPluginUrl.href);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   plugin = (builtPlugin as { default: Plugin }).default;
 });
 
@@ -782,6 +789,7 @@ describe.sequential("built plugin", () => {
         tool: "mcp_test_tool",
         args: { query: "test" },
       },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
       {
         content: [
           { type: "text", text: "MCP tool result" },
@@ -810,6 +818,7 @@ describe.sequential("built plugin", () => {
         tool: "mcp_failing_tool",
         args: { query: "fail" },
       },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
       {
         content: [{ type: "text", text: "MCP tool failed" }],
         isError: true,

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -136,6 +136,14 @@ const PluginEventSchema = Schema.declare(
     "properties" in input,
 );
 
+const PluginClientSchema = Schema.declare(
+  (input): input is Parameters<Plugin>[0]["client"] =>
+    typeof input === "object" &&
+    input !== null &&
+    "app" in input &&
+    "tool" in input,
+);
+
 const packageJson = Schema.decodeUnknownSync(
   Schema.parseJson(Schema.Struct({ version: Schema.String })),
 )(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
@@ -388,8 +396,7 @@ const completeGeneration = async (input: {
 
 const createHooks = async (baseUrl: string) => {
   process.env.LANGFUSE_BASE_URL = baseUrl;
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-  const client = {
+  const client = Schema.decodeUnknownSync(PluginClientSchema)({
     app: {
       log: () => Promise.resolve(),
     },
@@ -425,7 +432,7 @@ const createHooks = async (baseUrl: string) => {
         });
       },
     },
-  } as unknown as Parameters<Plugin>[0]["client"];
+  });
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
   return plugin({ client } as Parameters<Plugin>[0]);

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -567,8 +567,11 @@ afterAll(async () => {
   try {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
-        error ? reject(error) : resolve();
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
       });
     });
   } finally {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -668,13 +668,15 @@ describe("built plugin", { concurrent: false }, () => {
       (span) =>
         span.name === "opencode.turn" || span.name === "opencode.message.user",
     )) {
-      expect(getJsonAttribute(span, "langfuse.observation.input")).toEqual([
-        {
-          role: "user",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
-          content: expect.any(Array),
-        },
-      ]);
+      const input = Schema.decodeUnknownSync(
+        Schema.Array(
+          Schema.Struct({
+            role: Schema.Literal("user"),
+            content: Schema.Array(Schema.Unknown),
+          }),
+        ),
+      )(getJsonAttribute(span, "langfuse.observation.input"));
+      expect(input).toHaveLength(1);
     }
     for (const turn of spans.filter((span) => span.name === "opencode.turn")) {
       expect(getAttributes(turn)).toMatchObject({

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2136,8 +2136,7 @@ describe("built plugin", { concurrent: false }, () => {
       throw new Error("Expected the unavailable collector to use a TCP port");
     }
     hooksDisposed = false;
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-    hooks = await createHooks(`http://127.0.0.1:${address.port}`);
+    hooks = await createHooks(`http://127.0.0.1:${address.port.toString()}`);
     try {
       await sendUserMessage({
         sessionID: "unreachable-collector-session",

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2060,8 +2060,7 @@ describe.sequential("built plugin", () => {
       unavailableServer.listen(0, "127.0.0.1", resolve);
     });
     const address = unavailableServer.address();
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-    if (!address || typeof address === "string") {
+    if (address === null || typeof address === "string") {
       throw new Error("Expected the unavailable collector to use a TCP port");
     }
     hooksDisposed = false;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -128,6 +128,14 @@ type TestPluginEvent =
       };
     };
 
+const PluginEventSchema = Schema.declare(
+  (input): input is PluginEvent =>
+    typeof input === "object" &&
+    input !== null &&
+    "type" in input &&
+    "properties" in input,
+);
+
 const packageJson = Schema.decodeUnknownSync(
   Schema.parseJson(Schema.Struct({ version: Schema.String })),
 )(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
@@ -219,8 +227,9 @@ const getSessionSpan = (spans: OtlpSpan[], name: string, sessionID: string) => {
 const emitEvent = async (event: TestPluginEvent) => {
   // These events are emitted by current OpenCode versions but are not yet part of
   // the PluginEvent union exported by our pinned @opencode-ai/plugin version.
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-  await hooks.event?.({ event: event as PluginEvent });
+  await hooks.event?.({
+    event: Schema.decodeUnknownSync(PluginEventSchema)(event),
+  });
 };
 
 const flushSession = async (sessionID: string) => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -176,6 +176,16 @@ const PluginModuleSchema = Schema.declare(
     typeof input.default === "function",
 );
 
+const McpToolOutputSchema = Schema.declare(
+  (
+    input,
+  ): input is Parameters<NonNullable<PluginHooks["tool.execute.after"]>>[1] =>
+    typeof input === "object" &&
+    input !== null &&
+    "content" in input &&
+    Array.isArray(input.content),
+);
+
 const packageJson = Schema.decodeUnknownSync(
   Schema.parseJson(Schema.Struct({ version: Schema.String })),
 )(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
@@ -829,8 +839,7 @@ describe.sequential("built plugin", () => {
         tool: "mcp_test_tool",
         args: { query: "test" },
       },
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-      {
+      Schema.decodeUnknownSync(McpToolOutputSchema)({
         content: [
           { type: "text", text: "MCP tool result" },
           {
@@ -842,9 +851,7 @@ describe.sequential("built plugin", () => {
           },
           { type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
         ],
-      } as unknown as Parameters<
-        NonNullable<PluginHooks["tool.execute.after"]>
-      >[1],
+      }),
     );
     const failedMcpCallID = "nested-observations-failed-mcp-call";
     await hooks["tool.execute.before"]?.(

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1159,8 +1159,7 @@ describe("built plugin", { concurrent: false }, () => {
     const started = startedAt;
     const generations = [1, 2, 3].map((index) => ({
       assistantMessageID: `out-of-order-tool-parenting-assistant-${index.toString()}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-      stepID: `out-of-order-tool-parenting-step-${index}`,
+      stepID: `out-of-order-tool-parenting-step-${index.toString()}`,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       tool: `out-of-order-tool-${index}`,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -584,8 +584,7 @@ afterAll(async () => {
       LANGFUSE_USER_ID: originalEnvironment.userId,
     })) {
       if (value === undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation tracked for incremental cleanup.
-        delete process.env[name];
+        Reflect.deleteProperty(process.env, name);
       } else {
         process.env[name] = value;
       }

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -477,7 +477,7 @@ beforeAll(async () => {
 
   process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
   process.env.LANGFUSE_SECRET_KEY = "sk-test";
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
   collectorBaseUrl = `http://127.0.0.1:${address.port}`;
   process.env.LANGFUSE_BASE_URL = collectorBaseUrl;
   process.env.LANGFUSE_ENVIRONMENT = "integration-test";

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2154,7 +2154,7 @@ describe.sequential("built plugin", () => {
     } finally {
       for (const [name, value] of Object.entries(originalValues)) {
         if (value === undefined) {
-          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation tracked for incremental cleanup.
           delete process.env[name];
         } else {
           process.env[name] = value;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -338,6 +338,7 @@ const completeGeneration = async (input: {
   completed: number;
   text?: string;
 }) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
   if (input.text) {
     await emitEvent({
       type: "message.part.updated",
@@ -439,7 +440,9 @@ beforeAll(async () => {
   server = createServer((request, response) => {
     const chunks: Buffer[] = [];
 
+    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
     request.on("error", (error) => collectorErrors.push(error));
+    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
       try {
@@ -471,6 +474,7 @@ beforeAll(async () => {
   });
 
   const address = server.address();
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
   if (!address || typeof address === "string") {
     throw new Error("Expected the test collector to listen on a TCP port");
   }
@@ -506,6 +510,7 @@ afterEach(async () => {
 afterAll(async () => {
   try {
     await new Promise<void>((resolve, reject) =>
+      // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
       server.close((error) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
         error ? reject(error) : resolve();
@@ -1633,6 +1638,7 @@ describe.sequential("built plugin", () => {
 
     const spanIds = new Set(spans.map((span) => span.spanId));
     for (const span of spans) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
       if (span.parentSpanId) {
         expect(spanIds.has(span.parentSpanId)).toBe(true);
       }
@@ -2048,12 +2054,14 @@ describe.sequential("built plugin", () => {
       process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT;
     process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "100";
     const unavailableServer = createServer();
+    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
     unavailableServer.on("connection", (socket) => socket.destroy());
     await new Promise<void>((resolve, reject) => {
       unavailableServer.once("error", reject);
       unavailableServer.listen(0, "127.0.0.1", resolve);
     });
     const address = unavailableServer.address();
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
     if (!address || typeof address === "string") {
       throw new Error("Expected the unavailable collector to use a TCP port");
     }
@@ -2079,6 +2087,7 @@ describe.sequential("built plugin", () => {
       try {
         await disposeHooks();
         await new Promise<void>((resolve, reject) =>
+          // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
           unavailableServer.close((error) => {
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
             error ? reject(error) : resolve();

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2084,13 +2084,12 @@ describe.sequential("built plugin", () => {
     } finally {
       try {
         await disposeHooks();
-        await new Promise<void>((resolve, reject) =>
-          // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
+        await new Promise<void>((resolve, reject) => {
           unavailableServer.close((error) => {
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
             error ? reject(error) : resolve();
-          }),
-        );
+          });
+        });
       } finally {
         if (originalExporterTimeout === undefined) {
           delete process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -509,13 +509,12 @@ afterEach(async () => {
 
 afterAll(async () => {
   try {
-    await new Promise<void>((resolve, reject) =>
-      // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
+    await new Promise<void>((resolve, reject) => {
       server.close((error) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
         error ? reject(error) : resolve();
-      }),
-    );
+      });
+    });
   } finally {
     for (const [name, value] of Object.entries({
       LANGFUSE_PUBLIC_KEY: originalEnvironment.publicKey,

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1381,7 +1381,7 @@ describe.sequential("built plugin", () => {
 
     const toolSpans = spans.filter((span) => span.name === "bash");
     expect(toolSpans).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
     expect(toolSpans[0].parentSpanId).toBe(firstGeneration!.spanId);
     expect(toolSpans[0].startTimeUnixNano).toBe(
       (BigInt(toolStarted) * 1_000_000n).toString(),

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -168,6 +168,14 @@ const PluginInputSchema = Schema.declare(
     typeof input === "object" && input !== null && "client" in input,
 );
 
+const PluginModuleSchema = Schema.declare(
+  (input): input is { default: Plugin } =>
+    typeof input === "object" &&
+    input !== null &&
+    "default" in input &&
+    typeof input.default === "function",
+);
+
 const packageJson = Schema.decodeUnknownSync(
   Schema.parseJson(Schema.Struct({ version: Schema.String })),
 )(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
@@ -529,8 +537,7 @@ beforeAll(async () => {
 
   const builtPluginUrl = new URL("../../dist/index.js", import.meta.url);
   const builtPlugin: unknown = await import(builtPluginUrl.href);
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-  plugin = (builtPlugin as { default: Plugin }).default;
+  plugin = Schema.decodeUnknownSync(PluginModuleSchema)(builtPlugin).default;
 });
 
 beforeEach(async () => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1436,13 +1436,14 @@ describe("built plugin", { concurrent: false }, () => {
       });
     const firstGeneration = findGeneration(firstAssistantMessageID);
     const secondGeneration = findGeneration(secondAssistantMessageID);
-    expect(firstGeneration).toBeDefined();
+    if (!firstGeneration) {
+      throw new Error("Expected the first generation");
+    }
     expect(secondGeneration).toBeDefined();
 
     const toolSpans = spans.filter((span) => span.name === "bash");
     expect(toolSpans).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
-    expect(toolSpans[0].parentSpanId).toBe(firstGeneration!.spanId);
+    expect(toolSpans[0].parentSpanId).toBe(firstGeneration.spanId);
     expect(toolSpans[0].startTimeUnixNano).toBe(
       (BigInt(toolStarted) * 1_000_000n).toString(),
     );

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -608,7 +608,7 @@ describe.sequential("built plugin", () => {
       expect(getJsonAttribute(span, "langfuse.observation.input")).toEqual([
         {
           role: "user",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
           content: expect.any(Array),
         },
       ]);

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2052,8 +2052,9 @@ describe.sequential("built plugin", () => {
       process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT;
     process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "100";
     const unavailableServer = createServer();
-    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
-    unavailableServer.on("connection", (socket) => socket.destroy());
+    unavailableServer.on("connection", (socket) => {
+      socket.destroy();
+    });
     await new Promise<void>((resolve, reject) => {
       unavailableServer.once("error", reject);
       unavailableServer.listen(0, "127.0.0.1", resolve);

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -504,8 +504,10 @@ afterEach(async () => {
 afterAll(async () => {
   try {
     await new Promise<void>((resolve, reject) =>
-      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
-      server.close((error) => (error ? reject(error) : resolve())),
+      server.close((error) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
+        error ? reject(error) : resolve();
+      }),
     );
   } finally {
     for (const [name, value] of Object.entries({

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1160,8 +1160,7 @@ describe("built plugin", { concurrent: false }, () => {
     const generations = [1, 2, 3].map((index) => ({
       assistantMessageID: `out-of-order-tool-parenting-assistant-${index.toString()}`,
       stepID: `out-of-order-tool-parenting-step-${index.toString()}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-      tool: `out-of-order-tool-${index}`,
+      tool: `out-of-order-tool-${index.toString()}`,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       callID: `out-of-order-tool-parenting-call-${index}`,
     }));

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -14,34 +14,53 @@ import {
   test,
 } from "vitest";
 
-type OtlpValue = {
-  stringValue?: string;
-  boolValue?: boolean;
-  intValue?: number;
-};
+const OtlpValueSchema = Schema.Struct({
+  stringValue: Schema.optional(Schema.String),
+  boolValue: Schema.optional(Schema.Boolean),
+  intValue: Schema.optional(Schema.Number),
+});
+const OtlpAttributeSchema = Schema.Struct({
+  key: Schema.String,
+  value: OtlpValueSchema,
+});
+const OtlpSpanSchema = Schema.Struct({
+  name: Schema.String,
+  traceId: Schema.String,
+  spanId: Schema.String,
+  parentSpanId: Schema.optional(Schema.String),
+  startTimeUnixNano: Schema.String,
+  endTimeUnixNano: Schema.String,
+  attributes: Schema.Array(OtlpAttributeSchema),
+  status: Schema.optional(
+    Schema.Struct({
+      code: Schema.optional(Schema.Number),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+  events: Schema.optional(Schema.Array(Schema.Struct({ name: Schema.String }))),
+});
+const CapturedRequestBodySchema = Schema.Struct({
+  resourceSpans: Schema.Array(
+    Schema.Struct({
+      resource: Schema.optional(
+        Schema.Struct({
+          attributes: Schema.optional(Schema.Array(OtlpAttributeSchema)),
+        }),
+      ),
+      scopeSpans: Schema.Array(
+        Schema.Struct({ spans: Schema.Array(OtlpSpanSchema) }),
+      ),
+    }),
+  ),
+});
 
-type OtlpSpan = {
-  name: string;
-  traceId: string;
-  spanId: string;
-  parentSpanId?: string;
-  startTimeUnixNano: string;
-  endTimeUnixNano: string;
-  attributes: { key: string; value: OtlpValue }[];
-  status?: { code?: number; message?: string };
-  events?: { name: string }[];
-};
+type OtlpSpan = typeof OtlpSpanSchema.Type;
 
 type CapturedRequest = {
   method?: string;
   url?: string;
   headers: IncomingHttpHeaders;
-  body: {
-    resourceSpans: {
-      resource?: { attributes?: { key: string; value: OtlpValue }[] };
-      scopeSpans: { spans: OtlpSpan[] }[];
-    }[];
-  };
+  body: typeof CapturedRequestBodySchema.Type;
 };
 
 type Plugin = (typeof import("../../dist/index.js"))["default"];
@@ -471,10 +490,9 @@ beforeAll(async () => {
           method: request.method,
           url: request.url,
           headers: request.headers,
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-          body: JSON.parse(
-            Buffer.concat(chunks).toString("utf8"),
-          ) as CapturedRequest["body"],
+          body: Schema.decodeUnknownSync(
+            Schema.parseJson(CapturedRequestBodySchema),
+          )(Buffer.concat(chunks).toString("utf8")),
         });
         response.writeHead(collectorStatus, {
           "content-type": "application/json",

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1284,9 +1284,12 @@ describe("built plugin", { concurrent: false }, () => {
         );
       });
 
-      expect(span).toBeDefined();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
-      return span!;
+      if (!span) {
+        throw new Error(
+          `Expected generation for ${generation.assistantMessageID}`,
+        );
+      }
+      return span;
     });
     const toolSpans = generations.map((generation) =>
       getSpan(spans, generation.tool),

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -442,8 +442,9 @@ beforeAll(async () => {
     request.on("error", (error) => {
       collectorErrors.push(error);
     });
-    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
-    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
     request.on("end", () => {
       try {
         requests.push({

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -13,43 +13,35 @@ import {
   test,
 } from "vitest";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
-interface OtlpValue {
+type OtlpValue = {
   stringValue?: string;
   boolValue?: boolean;
   intValue?: number;
-}
+};
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
-interface OtlpSpan {
+type OtlpSpan = {
   name: string;
   traceId: string;
   spanId: string;
   parentSpanId?: string;
   startTimeUnixNano: string;
   endTimeUnixNano: string;
-  // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
-  attributes: Array<{ key: string; value: OtlpValue }>;
+  attributes: { key: string; value: OtlpValue }[];
   status?: { code?: number; message?: string };
-  // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
-  events?: Array<{ name: string }>;
-}
+  events?: { name: string }[];
+};
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
-interface CapturedRequest {
+type CapturedRequest = {
   method?: string;
   url?: string;
   headers: IncomingHttpHeaders;
   body: {
-    // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
-    resourceSpans: Array<{
-      // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
-      resource?: { attributes?: Array<{ key: string; value: OtlpValue }> };
-      // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
-      scopeSpans: Array<{ spans: OtlpSpan[] }>;
-    }>;
+    resourceSpans: {
+      resource?: { attributes?: { key: string; value: OtlpValue }[] };
+      scopeSpans: { spans: OtlpSpan[] }[];
+    }[];
   };
-}
+};
 
 type Plugin = (typeof import("../../dist/index.js"))["default"];
 type PluginHooks = Awaited<ReturnType<Plugin>>;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -865,13 +865,10 @@ describe.sequential("built plugin", () => {
         tool: "mcp_failing_tool",
         args: { query: "fail" },
       },
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-      {
+      Schema.decodeUnknownSync(McpToolOutputSchema)({
         content: [{ type: "text", text: "MCP tool failed" }],
         isError: true,
-      } as unknown as Parameters<
-        NonNullable<PluginHooks["tool.execute.after"]>
-      >[1],
+      }),
     );
     await emitEvent({
       type: "message.part.updated",

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2236,8 +2236,7 @@ describe("built plugin", { concurrent: false }, () => {
     } finally {
       for (const [name, value] of Object.entries(originalValues)) {
         if (value === undefined) {
-          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation tracked for incremental cleanup.
-          delete process.env[name];
+          Reflect.deleteProperty(process.env, name);
         } else {
           process.env[name] = value;
         }

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1228,7 +1228,7 @@ describe.sequential("built plugin", () => {
       });
 
       expect(span).toBeDefined();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
       return span!;
     });
     const toolSpans = generations.map((generation) =>

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -475,8 +475,7 @@ beforeAll(async () => {
   });
 
   const address = server.address();
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Existing violation; fix separately.
-  if (!address || typeof address === "string") {
+  if (address === null || typeof address === "string") {
     throw new Error("Expected the test collector to listen on a TCP port");
   }
 

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1731,22 +1731,29 @@ describe("built plugin", { concurrent: false }, () => {
       cache_write: 1,
       total: 17,
     });
-    expect(getJsonAttribute(generation, "langfuse.observation.output")).toEqual(
-      [
-        expect.objectContaining({
-          role: "assistant",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
-          content: expect.stringContaining("Recovered answer"),
-          tool_calls: [
-            {
-              id: "stream-error-retry-call-1",
-              name: "bash",
-              arguments: JSON.stringify({ command: "echo retry" }),
-            },
-          ],
+    const output = Schema.decodeUnknownSync(
+      Schema.Array(
+        Schema.Struct({
+          role: Schema.Literal("assistant"),
+          content: Schema.String,
+          tool_calls: Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+              arguments: Schema.String,
+            }),
+          ),
         }),
-      ],
-    );
+      ),
+    )(getJsonAttribute(generation, "langfuse.observation.output"));
+    expect(output[0].content).toContain("Recovered answer");
+    expect(output[0].tool_calls).toEqual([
+      {
+        id: "stream-error-retry-call-1",
+        name: "bash",
+        arguments: JSON.stringify({ command: "echo retry" }),
+      },
+    ]);
 
     expect(getSpan(spans, "bash").parentSpanId).toBe(generation.spanId);
     expect(getSpan(spans, "grep").parentSpanId).toBe(generation.spanId);

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -528,7 +528,7 @@ afterAll(async () => {
   }
 });
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing violation; fix separately.
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing violation tracked for incremental cleanup.
 describe.sequential("built plugin", () => {
   test("exports a complete multi-turn OpenCode session", async () => {
     const sessionID = "happy-session";

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1399,7 +1399,7 @@ describe.sequential("built plugin", () => {
       output: "07f9a68 Fix tool observation parenting",
     });
     expect(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
       getJsonAttribute(secondGeneration!, "langfuse.observation.input"),
     ).toEqual([
       {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1820,22 +1820,31 @@ describe("built plugin", { concurrent: false }, () => {
 
     const retry = await flushSession(retrySessionID);
     expect(toolListCalls).toBe(2);
-    expect(
+    const input = Schema.decodeUnknownSync(
+      Schema.Array(
+        Schema.Struct({
+          role: Schema.Literal("user"),
+          content: Schema.Array(
+            Schema.Struct({
+              type: Schema.Literal("text"),
+              text: Schema.String,
+            }),
+          ),
+          tools: Schema.Array(Schema.Struct({ name: Schema.String })),
+        }),
+      ),
+    )(
       getJsonAttribute(
         getSpan(retry.spans, "opencode.generation"),
         "langfuse.observation.input",
       ),
-    ).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "Retry tool discovery" }],
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
-        tools: expect.arrayContaining([
-          expect.objectContaining({ name: "read" }),
-          expect.objectContaining({ name: "webfetch" }),
-        ]),
-      },
+    );
+    expect(input[0].content).toEqual([
+      { type: "text", text: "Retry tool discovery" },
     ]);
+    expect(input[0].tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["read", "webfetch"]),
+    );
   });
 
   test("preserves step metadata when the assistant message arrives later", async () => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1161,8 +1161,7 @@ describe("built plugin", { concurrent: false }, () => {
       assistantMessageID: `out-of-order-tool-parenting-assistant-${index.toString()}`,
       stepID: `out-of-order-tool-parenting-step-${index.toString()}`,
       tool: `out-of-order-tool-${index.toString()}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
-      callID: `out-of-order-tool-parenting-call-${index}`,
+      callID: `out-of-order-tool-parenting-call-${index.toString()}`,
     }));
 
     const executeTool = async (generation: (typeof generations)[number]) => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -465,8 +465,9 @@ beforeAll(async () => {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
-    server.listen(0, "127.0.0.1", () => resolve());
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
   });
 
   const address = server.address();

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2077,10 +2077,10 @@ describe.sequential("built plugin", () => {
       try {
         await disposeHooks();
         await new Promise<void>((resolve, reject) =>
-          unavailableServer.close((error) =>
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
-            error ? reject(error) : resolve(),
-          ),
+          unavailableServer.close((error) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
+            error ? reject(error) : resolve();
+          }),
         );
       } finally {
         if (originalExporterTimeout === undefined) {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1097,13 +1097,13 @@ describe.sequential("built plugin", () => {
     const userMessageID = "out-of-order-tool-parenting-user";
     const started = startedAt;
     const generations = [1, 2, 3].map((index) => ({
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       assistantMessageID: `out-of-order-tool-parenting-assistant-${index}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       stepID: `out-of-order-tool-parenting-step-${index}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       tool: `out-of-order-tool-${index}`,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
       callID: `out-of-order-tool-parenting-call-${index}`,
     }));
 

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -144,6 +144,11 @@ const PluginClientSchema = Schema.declare(
     "tool" in input,
 );
 
+const PluginInputSchema = Schema.declare(
+  (input): input is Parameters<Plugin>[0] =>
+    typeof input === "object" && input !== null && "client" in input,
+);
+
 const packageJson = Schema.decodeUnknownSync(
   Schema.parseJson(Schema.Struct({ version: Schema.String })),
 )(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
@@ -434,8 +439,7 @@ const createHooks = async (baseUrl: string) => {
     },
   });
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-  return plugin({ client } as Parameters<Plugin>[0]);
+  return plugin(Schema.decodeUnknownSync(PluginInputSchema)({ client }));
 };
 
 const disposeHooks = async () => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import type { IncomingHttpHeaders, Server } from "node:http";
 
 import { trace } from "@opentelemetry/api";
+import { Schema } from "effect";
 import {
   afterAll,
   afterEach,
@@ -127,14 +128,9 @@ type TestPluginEvent =
       };
     };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-const packageJson = JSON.parse(
-  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
-) as { version?: unknown };
-
-if (typeof packageJson.version !== "string") {
-  throw new Error("Expected package.json to contain a version");
-}
+const packageJson = Schema.decodeUnknownSync(
+  Schema.parseJson(Schema.Struct({ version: Schema.String })),
+)(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
 
 const packageVersion = packageJson.version;
 

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -592,8 +592,7 @@ afterAll(async () => {
   }
 });
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing violation tracked for incremental cleanup.
-describe.sequential("built plugin", () => {
+describe("built plugin", { concurrent: false }, () => {
   test("exports a complete multi-turn OpenCode session", async () => {
     const sessionID = "happy-session";
     const started = startedAt;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1673,7 +1673,7 @@ describe.sequential("built plugin", () => {
       [
         expect.objectContaining({
           role: "assistant",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
           content: expect.stringContaining("Recovered answer"),
           tool_calls: [
             {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -338,7 +338,7 @@ const completeGeneration = async (input: {
   completed: number;
   text?: string;
 }) => {
-  if (input.text ?? "") {
+  if (input.text !== undefined && input.text !== "") {
     await emitEvent({
       type: "message.part.updated",
       properties: {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -519,7 +519,7 @@ afterAll(async () => {
       LANGFUSE_USER_ID: originalEnvironment.userId,
     })) {
       if (value === undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation; fix separately.
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation tracked for incremental cleanup.
         delete process.env[name];
       } else {
         process.env[name] = value;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1760,7 +1760,7 @@ describe.sequential("built plugin", () => {
       {
         role: "user",
         content: [{ type: "text", text: "Retry tool discovery" }],
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation tracked for incremental cleanup.
         tools: expect.arrayContaining([
           expect.objectContaining({ name: "read" }),
           expect.objectContaining({ name: "webfetch" }),

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -186,8 +186,7 @@ const getJsonAttribute = (span: OtlpSpan, key: string) => {
     throw new Error(`Expected ${span.name} attribute ${key} to be JSON`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Existing assertion; replace separately.
-  return JSON.parse(value) as unknown;
+  return Schema.decodeUnknownSync(Schema.parseJson(Schema.Unknown))(value);
 };
 
 const getSpan = (spans: OtlpSpan[], name: string) => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1439,7 +1439,9 @@ describe("built plugin", { concurrent: false }, () => {
     if (!firstGeneration) {
       throw new Error("Expected the first generation");
     }
-    expect(secondGeneration).toBeDefined();
+    if (!secondGeneration) {
+      throw new Error("Expected the second generation");
+    }
 
     const toolSpans = spans.filter((span) => span.name === "bash");
     expect(toolSpans).toHaveLength(1);
@@ -1460,8 +1462,7 @@ describe("built plugin", { concurrent: false }, () => {
       output: "07f9a68 Fix tool observation parenting",
     });
     expect(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation tracked for incremental cleanup.
-      getJsonAttribute(secondGeneration!, "langfuse.observation.input"),
+      getJsonAttribute(secondGeneration, "langfuse.observation.input"),
     ).toEqual([
       {
         role: "assistant",

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2157,8 +2157,11 @@ describe("built plugin", { concurrent: false }, () => {
         await disposeHooks();
         await new Promise<void>((resolve, reject) => {
           unavailableServer.close((error) => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Existing violation tracked for incremental cleanup.
-            error ? reject(error) : resolve();
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
           });
         });
       } finally {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -439,8 +439,9 @@ beforeAll(async () => {
   server = createServer((request, response) => {
     const chunks: Buffer[] = [];
 
-    // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
-    request.on("error", (error) => collectorErrors.push(error));
+    request.on("error", (error) => {
+      collectorErrors.push(error);
+    });
     // eslint-disable-next-line @typescript-eslint/strict-void-return -- Existing violation; fix separately.
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -13,12 +13,14 @@ import {
   test,
 } from "vitest";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
 interface OtlpValue {
   stringValue?: string;
   boolValue?: boolean;
   intValue?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
 interface OtlpSpan {
   name: string;
   traceId: string;
@@ -26,18 +28,24 @@ interface OtlpSpan {
   parentSpanId?: string;
   startTimeUnixNano: string;
   endTimeUnixNano: string;
+  // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
   attributes: Array<{ key: string; value: OtlpValue }>;
   status?: { code?: number; message?: string };
+  // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
   events?: Array<{ name: string }>;
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Existing violation; fix separately.
 interface CapturedRequest {
   method?: string;
   url?: string;
   headers: IncomingHttpHeaders;
   body: {
+    // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
     resourceSpans: Array<{
+      // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
       resource?: { attributes?: Array<{ key: string; value: OtlpValue }> };
+      // eslint-disable-next-line @typescript-eslint/array-type -- Existing violation; fix separately.
       scopeSpans: Array<{ spans: OtlpSpan[] }>;
     }>;
   };
@@ -465,6 +473,7 @@ beforeAll(async () => {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
+    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
     server.listen(0, "127.0.0.1", () => resolve());
   });
 
@@ -475,6 +484,7 @@ beforeAll(async () => {
 
   process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
   process.env.LANGFUSE_SECRET_KEY = "sk-test";
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
   collectorBaseUrl = `http://127.0.0.1:${address.port}`;
   process.env.LANGFUSE_BASE_URL = collectorBaseUrl;
   process.env.LANGFUSE_ENVIRONMENT = "integration-test";
@@ -501,6 +511,7 @@ afterEach(async () => {
 afterAll(async () => {
   try {
     await new Promise<void>((resolve, reject) =>
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
       server.close((error) => (error ? reject(error) : resolve())),
     );
   } finally {
@@ -513,6 +524,7 @@ afterAll(async () => {
       LANGFUSE_USER_ID: originalEnvironment.userId,
     })) {
       if (value === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation; fix separately.
         delete process.env[name];
       } else {
         process.env[name] = value;
@@ -521,6 +533,7 @@ afterAll(async () => {
   }
 });
 
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing violation; fix separately.
 describe.sequential("built plugin", () => {
   test("exports a complete multi-turn OpenCode session", async () => {
     const sessionID = "happy-session";
@@ -600,6 +613,7 @@ describe.sequential("built plugin", () => {
       expect(getJsonAttribute(span, "langfuse.observation.input")).toEqual([
         {
           role: "user",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
           content: expect.any(Array),
         },
       ]);
@@ -1088,9 +1102,13 @@ describe.sequential("built plugin", () => {
     const userMessageID = "out-of-order-tool-parenting-user";
     const started = startedAt;
     const generations = [1, 2, 3].map((index) => ({
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
       assistantMessageID: `out-of-order-tool-parenting-assistant-${index}`,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
       stepID: `out-of-order-tool-parenting-step-${index}`,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
       tool: `out-of-order-tool-${index}`,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
       callID: `out-of-order-tool-parenting-call-${index}`,
     }));
 
@@ -1215,6 +1233,7 @@ describe.sequential("built plugin", () => {
       });
 
       expect(span).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
       return span!;
     });
     const toolSpans = generations.map((generation) =>
@@ -1367,6 +1386,7 @@ describe.sequential("built plugin", () => {
 
     const toolSpans = spans.filter((span) => span.name === "bash");
     expect(toolSpans).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
     expect(toolSpans[0].parentSpanId).toBe(firstGeneration!.spanId);
     expect(toolSpans[0].startTimeUnixNano).toBe(
       (BigInt(toolStarted) * 1_000_000n).toString(),
@@ -1384,6 +1404,7 @@ describe.sequential("built plugin", () => {
       output: "07f9a68 Fix tool observation parenting",
     });
     expect(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Existing violation; fix separately.
       getJsonAttribute(secondGeneration!, "langfuse.observation.input"),
     ).toEqual([
       {
@@ -1657,6 +1678,7 @@ describe.sequential("built plugin", () => {
       [
         expect.objectContaining({
           role: "assistant",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
           content: expect.stringContaining("Recovered answer"),
           tool_calls: [
             {
@@ -1743,6 +1765,7 @@ describe.sequential("built plugin", () => {
       {
         role: "user",
         content: [{ type: "text", text: "Retry tool discovery" }],
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation; fix separately.
         tools: expect.arrayContaining([
           expect.objectContaining({ name: "read" }),
           expect.objectContaining({ name: "webfetch" }),
@@ -2038,6 +2061,7 @@ describe.sequential("built plugin", () => {
       throw new Error("Expected the unavailable collector to use a TCP port");
     }
     hooksDisposed = false;
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
     hooks = await createHooks(`http://127.0.0.1:${address.port}`);
     try {
       await sendUserMessage({
@@ -2059,6 +2083,7 @@ describe.sequential("built plugin", () => {
         await disposeHooks();
         await new Promise<void>((resolve, reject) =>
           unavailableServer.close((error) =>
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- Existing violation; fix separately.
             error ? reject(error) : resolve(),
           ),
         );
@@ -2134,6 +2159,7 @@ describe.sequential("built plugin", () => {
     } finally {
       for (const [name, value] of Object.entries(originalValues)) {
         if (value === undefined) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Existing violation; fix separately.
           delete process.env[name];
         } else {
           process.env[name] = value;

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -1637,7 +1637,7 @@ describe.sequential("built plugin", () => {
 
     const spanIds = new Set(spans.map((span) => span.spanId));
     for (const span of spans) {
-      if (span.parentSpanId ?? "") {
+      if (span.parentSpanId !== undefined && span.parentSpanId !== "") {
         expect(spanIds.has(span.parentSpanId)).toBe(true);
       }
     }

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -2056,7 +2056,7 @@ describe.sequential("built plugin", () => {
       throw new Error("Expected the unavailable collector to use a TCP port");
     }
     hooksDisposed = false;
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation; fix separately.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- Existing violation tracked for incremental cleanup.
     hooks = await createHooks(`http://127.0.0.1:${address.port}`);
     try {
       await sendUserMessage({

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.test.json",
+  "include": ["src/**/*.ts", "test/**/*.ts", "tsdown.config.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable core ESLint recommended rules and the requested strict type-aware rules
- restrict unambiguous truthiness coercion through `Boolean(...)`, while allowing legitimate `String(...)` and `Number(...)` conversions
- restrict negated inequality comparisons in favor of direct inverse operators
- keep rule enablement isolated and fix each occurrence in its own atomic commit
- leave no ESLint disable directives in the final tree
- add strict Knip checks in a standalone commit and keep CI enforcement last

## Verification
- `pnpm run format`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run knip`
- `pnpm run test:integration` (16 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15365](https://linear.app/clickhouse/issue/LFE-15365/setup-linting-for-opencode-plugin)

<div><a href="https://cursor.com/agents/bc-61796dc2-8318-4372-8569-49bb7eaf33bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61796dc2-8318-4372-8569-49bb7eaf33bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

